### PR TITLE
Flush writer once completed

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,5 +6,6 @@
 **🐛 Bug Fixes**
 - Use a `BufWriter` around a `File` to improve `save` performance.
     (https://github.com/kdr-aus/ogma/pull/77)
+- Flush `Write`r once finished writing. (https://github.com/kdr-aus/ogma/pull/78)
 
 **✨ Other Updates**

--- a/ogma/src/lang/impls/intrinsics/io.rs
+++ b/ogma/src/lang/impls/intrinsics/io.rs
@@ -376,7 +376,8 @@ fn write_file<W: Write>(file: &mut W, value: Value) -> io::Result<()> {
             write!(file, "{}", x)?;
         }
     }
-    Ok(())
+
+    file.flush()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix a potential writing bug by flushing the writer once completed writing.