### PR TITLE
Dumb output inference

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,9 @@
 **🛑 Breaking Changes**
 - [`to-str` now defaults to full number formatting with optional formatting string
     (https://github.com/kdr-aus/ogma/pull/85)
+- Output inference is somewhat smarter for variadic cmds.
+    (https://github.com/kdr-aus/ogma/pull/101)
+    It does place stricter typing constraints on `+ - * / min max`.
 
 **🔬 New Features**
 - `#b` -- Newline constant (b for _break_) (https://github.com/kdr-aus/ogma/pull/75)

--- a/docs/06 Variables.md
+++ b/docs/06 Variables.md
@@ -24,10 +24,10 @@ let {get:Num price} $price {get:Num carat} $ct | \$price | / $ct }
 
 ![](./assets/variables-1.png?raw=true)
 
-A more idiomatic way of achieving the same result without the use of variables is to use the dot
+A more idiomatic way of achieving the same result is to use the dot
 (`.`) operator:
 ```plaintext
-open diamonds.csv | append --'Price per Carat' / #i.price #i.carat
+open diamonds.csv | append --'Price per Carat' { let $i | get price | / $i.carat }
 ```
 
 ![](./assets/variables-2.gif?raw=true)

--- a/ogma/src/eng/comp/infer.rs
+++ b/ogma/src/eng/comp/infer.rs
@@ -190,7 +190,11 @@ fn input_via_expr_compilation<'a>(
 }
 
 fn output<'a>(op: OpNode, compiler: &Compiler_<'a>) -> std::result::Result<Compiler_<'a>, Error> {
-    test_compile_types(compiler, op.idx(), op.parent(compiler.ag()), true)
+    let ag = compiler.ag();
+    let brk = op.parent(ag);
+    //     let brk = brk.parent(ag).map(|x| x.parent(ag)).unwrap_or(brk);
+
+    test_compile_types(compiler, op.idx(), brk, true)
 }
 
 fn test_compile_types<'a>(

--- a/ogma/src/eng/graphs/mod.rs
+++ b/ogma/src/eng/graphs/mod.rs
@@ -668,4 +668,33 @@ mod tests {
         assert_eq!(f(19), e(&[0, 3, 4, 5, 9, 10, 13, 17, 18, 19]));
         assert_eq!(f(20), e(&[0, 3, 4, 5, 9, 10, 13, 17, 18, 19, 20]));
     }
+
+    #[test]
+    fn node_accessors() {
+        let (ag, _tg) = init_graphs("let $a | + { > 3 } | + - + 3");
+
+        assert_eq!(ag.node_count(), 32);
+
+        //         let s = &mut String::new();
+        //         ag.debug_write_flowchart(&_tg, s);
+        //         std::fs::write("foo", s).unwrap();
+
+        let g = &ag;
+
+        // OpNode
+        assert_eq!(OpNode(1.into()).next(g), Some(OpNode(3.into())));
+        assert_eq!(OpNode(3.into()).next(g), Some(OpNode(5.into())));
+        assert_eq!(OpNode(5.into()).next(g), None);
+        assert_eq!(OpNode(5.into()).prev(g), Some(OpNode(3.into())));
+        assert_eq!(OpNode(3.into()).prev(g), Some(OpNode(1.into())));
+        assert_eq!(OpNode(1.into()).prev(g), None);
+        assert_eq!(OpNode(3.into()).parent(g), ExprNode(0.into()));
+
+        // ExprNode
+        assert_eq!(ExprNode(0.into()).first_op(g), OpNode(1.into()));
+        assert_eq!(ExprNode(0.into()).parent(g), None);
+        assert_eq!(ExprNode(6.into()).parent(g), Some(OpNode(5.into())));
+        assert_eq!(ExprNode(17.into()).parent(g), Some(OpNode(7.into())));
+        assert_eq!(ExprNode(21.into()).parent(g), Some(OpNode(20.into())));
+    }
 }

--- a/ogma/src/lang/impls/intrinsics/arithmetic.rs
+++ b/ogma/src/lang/impls/intrinsics/arithmetic.rs
@@ -20,7 +20,7 @@ fn variadic_intrinsic_num<F>(blk: Block, f: F) -> Result<Step>
 where
     F: Fn(f64, f64) -> f64 + Send + Sync + 'static,
 {
-    variadic_intrinsic::<Number, _>(blk, move |prev, next| {
+    variadic_intrinsic_in_constrained::<Number, _>(blk, move |prev, next| {
         let x = f(prev.as_f64(), next.as_f64()).into();
         (x, false)
     })
@@ -67,7 +67,7 @@ if input is a Table, concat or join additional tables
 fn add_intrinsic(blk: Block) -> Result<Step> {
     match blk.in_ty() {
         Ty::Num => variadic_intrinsic_num(blk, std::ops::Add::add),
-        Ty::Str => variadic_intrinsic::<Str, _>(blk, |mut prev, next| {
+        Ty::Str => variadic_intrinsic_in_constrained::<Str, _>(blk, |mut prev, next| {
             prev.to_mut().push_str(&next);
             (prev, false)
         }),
@@ -81,7 +81,7 @@ fn add_table(mut blk: Block) -> Result<Step> {
     let byrow = !f("cols");
     let intersect = !f("union") && f("intersect");
 
-    variadic_intrinsic(blk, move |prev, next| {
+    variadic_intrinsic_in_constrained(blk, move |prev, next| {
         (add_table2(prev, next, byrow, intersect), false)
     })
 }

--- a/ogma/src/lang/impls/intrinsics/cmp.rs
+++ b/ogma/src/lang/impls/intrinsics/cmp.rs
@@ -303,7 +303,7 @@ fn max_help() -> HelpMessage {
 fn max_intrinsic(mut blk: Block) -> Result<Step> {
     blk.assert_output(Ty::Num);
     variadic_intrinsic::<Number, _>(blk, |prev, next| {
-        let x = prev.map(|prev| std::cmp::max(prev, next)).unwrap_or(next);
+        let x = std::cmp::max(prev, next);
         (x, false)
     })
 }
@@ -329,7 +329,7 @@ fn min_help() -> HelpMessage {
 fn min_intrinsic(mut blk: Block) -> Result<Step> {
     blk.assert_output(Ty::Num);
     variadic_intrinsic::<Number, _>(blk, |prev, next| {
-        let x = prev.map(|prev| std::cmp::min(prev, next)).unwrap_or(next);
+        let x = std::cmp::min(prev, next);
         (x, false)
     })
 }

--- a/ogma/src/lang/impls/intrinsics/cmp.rs
+++ b/ogma/src/lang/impls/intrinsics/cmp.rs
@@ -300,9 +300,8 @@ fn max_help() -> HelpMessage {
     )
 }
 
-fn max_intrinsic(mut blk: Block) -> Result<Step> {
-    blk.assert_output(Ty::Num);
-    variadic_intrinsic::<Number, _>(blk, |prev, next| {
+fn max_intrinsic(blk: Block) -> Result<Step> {
+    variadic_intrinsic_in_constrained::<Number, _>(blk, |prev, next| {
         let x = std::cmp::max(prev, next);
         (x, false)
     })
@@ -326,9 +325,8 @@ fn min_help() -> HelpMessage {
     )
 }
 
-fn min_intrinsic(mut blk: Block) -> Result<Step> {
-    blk.assert_output(Ty::Num);
-    variadic_intrinsic::<Number, _>(blk, |prev, next| {
+fn min_intrinsic(blk: Block) -> Result<Step> {
+    variadic_intrinsic_in_constrained::<Number, _>(blk, |prev, next| {
         let x = std::cmp::min(prev, next);
         (x, false)
     })

--- a/ogma/src/lang/impls/intrinsics/logic.rs
+++ b/ogma/src/lang/impls/intrinsics/logic.rs
@@ -21,9 +21,8 @@ fn and_help() -> HelpMessage {
     )
 }
 
-fn and_intrinsic(mut blk: Block) -> Result<Step> {
-    blk.assert_output(Ty::Bool);
-    variadic_intrinsic::<bool, _>(blk, |prev, next| {
+fn and_intrinsic(blk: Block) -> Result<Step> {
+    variadic_intrinsic_in_agnostic::<bool, _>(blk, |prev, next| {
         let x = prev && next;
         (x, !x) // short circuit if x is false
     })
@@ -143,10 +142,8 @@ fn or_help() -> HelpMessage {
     )
 }
 
-fn or_intrinsic(mut blk: Block) -> Result<Step> {
-    blk.assert_output(Ty::Bool); // or returns boolean
-
-    variadic_intrinsic::<bool, _>(blk, |prev, next| {
+fn or_intrinsic(blk: Block) -> Result<Step> {
+    variadic_intrinsic_in_agnostic::<bool, _>(blk, |prev, next| {
         let x = prev || next;
         (x, x) // short-circuit if true!
     })

--- a/ogma/src/lang/impls/intrinsics/logic.rs
+++ b/ogma/src/lang/impls/intrinsics/logic.rs
@@ -24,8 +24,7 @@ fn and_help() -> HelpMessage {
 fn and_intrinsic(mut blk: Block) -> Result<Step> {
     blk.assert_output(Ty::Bool);
     variadic_intrinsic::<bool, _>(blk, |prev, next| {
-        let x = prev.unwrap_or(true);
-        let x = x && next;
+        let x = prev && next;
         (x, !x) // short circuit if x is false
     })
 }
@@ -148,8 +147,7 @@ fn or_intrinsic(mut blk: Block) -> Result<Step> {
     blk.assert_output(Ty::Bool); // or returns boolean
 
     variadic_intrinsic::<bool, _>(blk, |prev, next| {
-        let x = prev.unwrap_or(false);
-        let x = x || next;
-        (x, x)
+        let x = prev || next;
+        (x, x) // short-circuit if true!
     })
 }

--- a/ogma/src/lang/impls/intrinsics/mod.rs
+++ b/ogma/src/lang/impls/intrinsics/mod.rs
@@ -149,7 +149,6 @@ where
         a
     };
 
-
     blk.eval_o(move |input, cx| {
         // we know arg.len() > 0
         let mut prev: T = args[0].resolve(|| input.clone(), &cx)?.try_into()?;

--- a/ogma/tests/commands/arithmetic.rs
+++ b/ogma/tests/commands/arithmetic.rs
@@ -355,8 +355,6 @@ fn div_help_msg() {
 #[test]
 fn div_testing() {
     let defs = &Definitions::new();
-    let x = process_w_nil("/ 5", defs);
-    assert_eq!(x, Ok(Value::Num((5).into())));
     let x = process_w_num("/ 6", defs);
     assert_eq!(x, Ok(Value::Num((0.5).into())));
     let x = process_w_num("let $x | \\ 30 | ÷ -5 $x", defs);
@@ -544,7 +542,7 @@ fn sub_testing() {
     let defs = &Definitions::new();
     let x = process_w_num("- 5", defs);
     assert_eq!(x, Ok(Value::Num((-2).into())));
-    let x = process_w_nil("- -2 -1", defs);
+    let x = process_w_nil("\\ -2 | - -1", defs);
     assert_eq!(x, Ok(Value::Num((-1).into())));
     let x = process_w_num("let $x | \\ 1 | - 1 2 $x", defs);
     assert_eq!(x, Ok(Value::Num((-5).into()))); // 1 - 1 - 2 - 3

--- a/ogma/tests/commands/mod.rs
+++ b/ogma/tests/commands/mod.rs
@@ -164,7 +164,7 @@ fn multiline_expr() {
 
     let x = process_w_nil(
         "
-* 3 4 |
+\\ 3 | * 4 |
 if {= 36}
     #f
     #t
@@ -239,7 +239,7 @@ fn multiline_errs() {
     let d = &Definitions::new();
 
     let x = process_w_nil(
-        "* 3 4 |
+        "\\ 3 | * 4 |
     * 'foo'",
         d,
     )

--- a/ogma/tests/commands/mod.rs
+++ b/ogma/tests/commands/mod.rs
@@ -732,7 +732,7 @@ fn get_output_inference_be_smarter() {
             vec![n(1), n(20), o("b"), n(2)],
             vec![n(-30), n(100), o("z"), n(-60)],
         ],
-  );
+    );
 }
 
 #[test]

--- a/ogma/tests/commands/mod.rs
+++ b/ogma/tests/commands/mod.rs
@@ -719,3 +719,18 @@ fn unrecognised_literal() {
 "
     );
 }
+
+#[test]
+fn get_output_inference_be_smarter() {
+    let x = process_w_table("append { get first | * 2 }", &Definitions::new());
+
+    check_is_table(
+        x,
+        vec![
+            vec![o("first"), o("snd"), o("Heading 3"), o("_append1")],
+            vec![n(0), n(3), o("a"), n(0)],
+            vec![n(1), n(20), o("b"), n(2)],
+            vec![n(-30), n(100), o("z"), n(-60)],
+        ],
+    );
+}

--- a/ogma/tests/commands/pipeline.rs
+++ b/ogma/tests/commands/pipeline.rs
@@ -500,7 +500,7 @@ fn assigning() {
     assert_eq!(x, Ok(Value::Bool(true)));
 
     let x = process_w_num(
-        "let {+ 1} $x {- 1} $y {= 3} $z | \\ $x | / $y | and {= 2} $z",
+        "let {+ 1} $x {- 1} $y {= 3} $z | \\ $x | / $y | = 2 | and $z",
         defs,
     );
     assert_eq!(x, Ok(Value::Bool(true)));

--- a/ogma/tests/doc-examples.rs
+++ b/ogma/tests/doc-examples.rs
@@ -196,7 +196,7 @@ let {get:Num price} $price {get:Num carat} $ct | \$price | / $ct }"#,
     .unwrap();
 
     let b = process(
-        r#"open tests/diamonds.csv | append --'Price per Carat' / #i.price #i.carat"#,
+        r#"open tests/diamonds.csv | append --'Price per Carat' { let $i | get price | / $i.carat }"#,
         defs,
     )
     .unwrap();


### PR DESCRIPTION
Fixes #71 

Does introduce stricter constraints on `+ - * / min max`.
This can be alleviated with a modifier (eg `+'`).