### PR TITLE
Separate intrinsics prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +952,7 @@ name = "ogma-ls"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "itertools",
  "libs",
  "log",
  "lsp-server",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,8 @@
 **🛑 Breaking Changes**
 
 **🔬 New Features**
+- Improve help messages for defs with multiple input types
+    (https://github.com/kdr-aus/ogma/pull/134)
 
 **🐛 Bug Fixes**
 - Fix variable type inferencing when passing variables to `def`s (https://github.com/kdr-aus/ogma/pull/115)

--- a/ogma-ls/Cargo.toml
+++ b/ogma-ls/Cargo.toml
@@ -18,6 +18,7 @@ ogma = { path = "../ogma" }
 
 # crates.io
 bitflags = "1"
+itertools = "0.10"
 log = "0.4"
 lsp-server = "0.5"
 lsp-types = "0.92"

--- a/ogma/src/common/err.rs
+++ b/ogma/src/common/err.rs
@@ -88,7 +88,7 @@ pub fn help_as_error(msg: &HelpMessage, in_ty: Option<&Type>) -> Error {
     use fmt::Write;
 
     let cmd = msg.cmd.as_str();
-    let mut source = format!("---- Input Type: ");
+    let mut source = "---- Input Type: ".to_string();
 
     match in_ty {
         Some(t) => write!(&mut source, "{t}"),

--- a/ogma/src/common/err.rs
+++ b/ogma/src/common/err.rs
@@ -84,11 +84,19 @@ pub struct Trace {
 }
 
 /// Represent a help message using the [`Error`] infrastructure.
-pub fn help_as_error(msg: &HelpMessage) -> Error {
+pub fn help_as_error(msg: &HelpMessage, in_ty: Option<&Type>) -> Error {
     use fmt::Write;
 
     let cmd = msg.cmd.as_str();
-    let mut source = format!("{}\n\nUsage:\n => {}", msg.desc, cmd);
+    let mut source = format!("---- Input Type: ");
+
+    match in_ty {
+        Some(t) => write!(&mut source, "{t}"),
+        None => write!(&mut source, "<any>"),
+    }
+    .ok();
+
+    source = source + " ----\n" + &msg.desc + "\n\nUsage:\n => " + cmd;
 
     for param in &msg.params {
         let brk = matches!(param, HelpParameter::Break);
@@ -182,7 +190,7 @@ impl Error {
             x.map(|x| x.to_string()).unwrap_or_else(|| "<any>".into())
         }
 
-        let ty = impls.iter().filter(|x| x.0 == op.str()).collect::<Vec<_>>();
+        let ty = impls.iter_op(op.str()).collect::<Vec<_>>();
 
         let hlp = if recursion_detected {
             "recursion is not supported.
@@ -191,8 +199,8 @@ impl Error {
             "view a list of definitions using `def --list`".into()
         } else {
             ty.into_iter().fold(
-                format!("`{}` is implemented for the following input types:", op),
-                |s, t| s + " " + &tystr(t.1),
+                format!("`{op}` is implemented for the following input types:"),
+                |s, t| s + " " + &tystr(t.ty),
             )
         };
 

--- a/ogma/src/eng/comp/params.rs
+++ b/ogma/src/eng/comp/params.rs
@@ -110,11 +110,15 @@ pub(super) fn map_def_params_into_variables(
             let impl_ = tg[op.idx()]
                 .input
                 .ty()
-                .and_then(|inty| defs.impls().get_impl(optag, inty).ok())
+                .and_then(|inty| defs.impls().get_impl_with_err(optag, inty).ok())
                 .or_else(|| {
                     defs.impls()
-                        .iter()
-                        .find_map(|x| (x.0 == optag.str()).then(|| x.2))
+                        .iter_op(optag.str())
+                        .map(|x| x.impl_)
+                        // TODO: this returns on the first match, but I don't think that is a reasonable
+                        // option???
+                        // Maybe it should fail if not typed???, dunno...
+                        .next()
                 })
                 .and_then(|i| match i {
                     Implementation::Definition(x) => Some(x.as_ref()),

--- a/ogma/src/eng/graphs/mod.rs
+++ b/ogma/src/eng/graphs/mod.rs
@@ -646,6 +646,8 @@ mod tests {
     fn path_from_root_test() {
         let (ag, _) = init_graphs("let $a | + { > 3 }");
 
+        assert_eq!(ag.node_count(), 25);
+
         let f = |n: u32| ag.path_from_root(n.into()).collect::<Vec<_>>();
         let e = |i: &[_]| i.iter().copied().map(Into::into).collect::<Vec<_>>();
 
@@ -656,28 +658,33 @@ mod tests {
         assert_eq!(f(4), e(&[0, 3, 4]));
         assert_eq!(f(5), e(&[0, 3, 4, 5]));
         assert_eq!(f(6), e(&[0, 3, 4, 5, 6]));
-        assert_eq!(f(9), e(&[0, 3, 4, 5, 9]));
-        assert_eq!(f(10), e(&[0, 3, 4, 5, 9, 10]));
-        assert_eq!(f(11), e(&[0, 3, 4, 5, 9, 10, 11]));
-        assert_eq!(f(12), e(&[0, 3, 4, 5, 9, 10, 11, 12]));
-        assert_eq!(f(13), e(&[0, 3, 4, 5, 9, 10, 13]));
-        assert_eq!(f(14), e(&[0, 3, 4, 5, 9, 10, 13, 14]));
-        assert_eq!(f(15), e(&[0, 3, 4, 5, 9, 10, 13, 14, 15]));
-        assert_eq!(f(17), e(&[0, 3, 4, 5, 9, 10, 13, 17]));
-        assert_eq!(f(18), e(&[0, 3, 4, 5, 9, 10, 13, 17, 18]));
-        assert_eq!(f(19), e(&[0, 3, 4, 5, 9, 10, 13, 17, 18, 19]));
-        assert_eq!(f(20), e(&[0, 3, 4, 5, 9, 10, 13, 17, 18, 19, 20]));
+        assert_eq!(f(9), e(&[0, 3, 9]));
+        assert_eq!(f(10), e(&[0, 3, 10]));
+        assert_eq!(f(11), e(&[0, 3, 4, 5, 11]));
+        assert_eq!(f(12), e(&[0, 3, 4, 5, 11, 12]));
+        assert_eq!(f(13), e(&[0, 3, 4, 5, 11, 12, 13]));
+        assert_eq!(f(14), e(&[0, 3, 4, 5, 11, 12, 13, 14]));
+        assert_eq!(f(15), e(&[0, 3, 4, 5, 11, 12, 15]));
+        assert_eq!(f(16), e(&[0, 3, 4, 5, 11, 12, 15, 16]));
+        assert_eq!(f(17), e(&[0, 3, 4, 5, 11, 12, 15, 16, 17]));
+        assert_eq!(f(18), e(&[0, 3, 4, 5, 11, 12, 13, 18]));
+        assert_eq!(f(19), e(&[0, 3, 4, 5, 11, 12, 15, 19]));
+        assert_eq!(f(20), e(&[0, 3, 4, 5, 11, 12, 15, 19, 20]));
+        assert_eq!(f(21), e(&[0, 3, 4, 5, 11, 12, 15, 19, 20, 21]));
+        assert_eq!(f(22), e(&[0, 3, 4, 5, 11, 12, 15, 19, 20, 21, 22]));
+        assert_eq!(f(23), e(&[0, 3, 4, 5, 11, 12, 15, 16, 17, 23]));
+        assert_eq!(f(24), e(&[0, 3, 4, 5, 11, 12, 15, 19, 20, 21, 24]));
     }
 
     #[test]
     fn node_accessors() {
         let (ag, _tg) = init_graphs("let $a | + { > 3 } | + - + 3");
 
-        assert_eq!(ag.node_count(), 32);
+        assert_eq!(ag.node_count(), 38);
 
-        //         let s = &mut String::new();
-        //         ag.debug_write_flowchart(&_tg, s);
-        //         std::fs::write("foo", s).unwrap();
+        let s = &mut String::new();
+        ag.debug_write_flowchart(&_tg, s);
+        std::fs::write("foo.md", s).unwrap();
 
         let g = &ag;
 
@@ -694,7 +701,7 @@ mod tests {
         assert_eq!(ExprNode(0.into()).first_op(g), OpNode(1.into()));
         assert_eq!(ExprNode(0.into()).parent(g), None);
         assert_eq!(ExprNode(6.into()).parent(g), Some(OpNode(5.into())));
-        assert_eq!(ExprNode(17.into()).parent(g), Some(OpNode(7.into())));
-        assert_eq!(ExprNode(21.into()).parent(g), Some(OpNode(20.into())));
+        assert_eq!(ExprNode(21.into()).parent(g), Some(OpNode(7.into())));
+        assert_eq!(ExprNode(25.into()).parent(g), Some(OpNode(24.into())));
     }
 }

--- a/ogma/src/eng/graphs/mod.rs
+++ b/ogma/src/eng/graphs/mod.rs
@@ -682,9 +682,9 @@ mod tests {
 
         assert_eq!(ag.node_count(), 38);
 
-        let s = &mut String::new();
-        ag.debug_write_flowchart(&_tg, s);
-        std::fs::write("foo.md", s).unwrap();
+//         let s = &mut String::new();
+//         ag.debug_write_flowchart(&_tg, s);
+//         std::fs::write("foo.md", s).unwrap();
 
         let g = &ag;
 

--- a/ogma/src/eng/graphs/mod.rs
+++ b/ogma/src/eng/graphs/mod.rs
@@ -682,9 +682,9 @@ mod tests {
 
         assert_eq!(ag.node_count(), 38);
 
-//         let s = &mut String::new();
-//         ag.debug_write_flowchart(&_tg, s);
-//         std::fs::write("foo.md", s).unwrap();
+        //         let s = &mut String::new();
+        //         ag.debug_write_flowchart(&_tg, s);
+        //         std::fs::write("foo.md", s).unwrap();
 
         let g = &ag;
 

--- a/ogma/src/lang/defs.rs
+++ b/ogma/src/lang/defs.rs
@@ -337,7 +337,7 @@ def has specialised syntax which takes variable params: ( )"
             ],
             ..HelpMessage::new("def")
         };
-        Err(err::help_as_error(&help))
+        Err(err::help_as_error(&help, None))
     } else if s.contains(" --list") {
         let post = s.split_once(" | ").map(|x| x.1);
         Ok((Value::Tab(construct_def_table(defs)), post))
@@ -480,15 +480,23 @@ pub fn construct_def_table(defs: &Definitions) -> Table {
     let mut rows = defs
         .impls
         .iter()
-        .map(|(name, ty, im)| {
-            let cat = Obj(defs.impls.get_cat(name).unwrap().to_string().into());
-            let name = Obj(name.clone());
-            let inty = ty.map(|t| Str::from(t.to_string())).map(Obj).unwrap_or(Nil);
-            let loc = Obj(location(im));
-            let line = line(im);
-            let code = code(im);
-            vec![name, cat, inty, loc, line, code]
-        })
+        .map(
+            |super::impls::ImplEntry {
+                 name,
+                 ty,
+                 cat,
+                 help: _,
+                 impl_,
+             }| {
+                let cat = Obj(cat.to_string().into());
+                let name = Obj(name.clone());
+                let inty = ty.map(|t| Str::from(t.to_string())).map(Obj).unwrap_or(Nil);
+                let loc = Obj(location(impl_));
+                let line = line(impl_);
+                let code = code(impl_);
+                vec![name, cat, inty, loc, line, code]
+            },
+        )
         .collect::<Vec<_>>();
 
     // we know we can unwrap because all names are strings which implement total ordering

--- a/ogma/src/lang/help.rs
+++ b/ogma/src/lang/help.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{err::help_as_error, Str};
+use crate::prelude::Str;
 use std::fmt;
 
 /// Help messages work off the back of error messages such that:
@@ -38,12 +38,6 @@ impl HelpMessage {
     }
 }
 
-impl fmt::Display for HelpMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", help_as_error(self))
-    }
-}
-
 #[derive(Clone)]
 pub enum HelpParameter {
     Required(Str),
@@ -73,6 +67,7 @@ pub struct HelpExample {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::err::help_as_error;
 
     #[test]
     fn help_msg() {
@@ -83,7 +78,7 @@ mod tests {
             params: vec![Required("required1".into()), Required("req2".into())],
             ..HelpMessage::new("cmd-name")
         };
-        let s = help_as_error(&h).to_string();
+        let s = help_as_error(&h, None).to_string();
         assert_eq!(
             &s,
             "Help: `cmd-name`
@@ -109,7 +104,7 @@ mod tests {
             ],
             ..HelpMessage::new("cmd-name")
         };
-        let s = help_as_error(&h).to_string();
+        let s = help_as_error(&h, None).to_string();
         assert_eq!(
             &s,
             "Help: `cmd-name`

--- a/ogma/src/lang/help.rs
+++ b/ogma/src/lang/help.rs
@@ -83,6 +83,7 @@ mod tests {
             &s,
             "Help: `cmd-name`
 --> shell:0
+ | ---- Input Type: <any> ----
  | this is a description
  | 
  | Usage:
@@ -104,11 +105,12 @@ mod tests {
             ],
             ..HelpMessage::new("cmd-name")
         };
-        let s = help_as_error(&h, None).to_string();
+        let s = help_as_error(&h, Some(&crate::prelude::Type::Tab)).to_string();
         assert_eq!(
             &s,
             "Help: `cmd-name`
 --> shell:0
+ | ---- Input Type: Table ----
  | this is a description
  | 
  | Usage:

--- a/ogma/src/lang/impls/intrinsics/arithmetic.rs
+++ b/ogma/src/lang/impls/intrinsics/arithmetic.rs
@@ -30,21 +30,10 @@ where
 
 // ------ Add ------------------------------------------------------------------
 fn add_num_help() -> HelpMessage {
-    HelpMessage {
-        desc: "add arguments together
-if input is a Table, concat or join additional tables
--variadic-: more than one argument can be specified"
-            .into(),
-        params: vec![HelpParameter::Required("args..".into())],
-        flags: vec![
-            ("cols", "join tables (append columns)"),
-            ("union", "expand table to capture all data (default)"),
-            (
-                "intersect",
-                "use minimum size of table; min rows for --cols, min cols for concat rows",
-            ),
-        ],
-        examples: vec![
+    variadic_help(
+        "+",
+        "add numbers together",
+        vec![
             HelpExample {
                 desc: "add 2 to 1",
                 code: "\\ 1 | + 2",
@@ -53,17 +42,8 @@ if input is a Table, concat or join additional tables
                 desc: "add multiple numbers together",
                 code: "+ 1 2 3 4 5",
             },
-            HelpExample {
-                desc: "add two tables together, concatenating rows",
-                code: "range 0 10 | + range 10 20",
-            },
-            HelpExample {
-                desc: "index filesystem items, shrink table to min rows",
-                code: "range 0 1000 | + --cols --intersect ls",
-            },
         ],
-        ..HelpMessage::new("+")
-    }
+    )
 }
 
 fn add_num_intrinsic(blk: Block) -> Result<Step> {
@@ -71,40 +51,20 @@ fn add_num_intrinsic(blk: Block) -> Result<Step> {
 }
 
 fn add_str_help() -> HelpMessage {
-    HelpMessage {
-        desc: "add arguments together
-if input is a Table, concat or join additional tables
--variadic-: more than one argument can be specified"
-            .into(),
-        params: vec![HelpParameter::Required("args..".into())],
-        flags: vec![
-            ("cols", "join tables (append columns)"),
-            ("union", "expand table to capture all data (default)"),
-            (
-                "intersect",
-                "use minimum size of table; min rows for --cols, min cols for concat rows",
-            ),
-        ],
-        examples: vec![
+    variadic_help(
+        "+",
+        "concatenate strings together",
+        vec![
             HelpExample {
-                desc: "add 2 to 1",
-                code: "\\ 1 | + 2",
+                desc: "join together strings",
+                code: "\\ Hello | + ', world!'",
             },
             HelpExample {
-                desc: "add multiple numbers together",
-                code: "+ 1 2 3 4 5",
-            },
-            HelpExample {
-                desc: "add two tables together, concatenating rows",
-                code: "range 0 10 | + range 10 20",
-            },
-            HelpExample {
-                desc: "index filesystem items, shrink table to min rows",
-                code: "range 0 1000 | + --cols --intersect ls",
+                desc: "join strings with a new line",
+                code: "\\ 'First Line' | + #b 'Second Line'",
             },
         ],
-        ..HelpMessage::new("+")
-    }
+    )
 }
 
 fn add_str_intrinsic(blk: Block) -> Result<Step> {
@@ -115,29 +75,10 @@ fn add_str_intrinsic(blk: Block) -> Result<Step> {
 }
 
 fn add_table_help() -> HelpMessage {
-    HelpMessage {
-        desc: "add arguments together
-if input is a Table, concat or join additional tables
--variadic-: more than one argument can be specified"
-            .into(),
-        params: vec![HelpParameter::Required("args..".into())],
-        flags: vec![
-            ("cols", "join tables (append columns)"),
-            ("union", "expand table to capture all data (default)"),
-            (
-                "intersect",
-                "use minimum size of table; min rows for --cols, min cols for concat rows",
-            ),
-        ],
-        examples: vec![
-            HelpExample {
-                desc: "add 2 to 1",
-                code: "\\ 1 | + 2",
-            },
-            HelpExample {
-                desc: "add multiple numbers together",
-                code: "+ 1 2 3 4 5",
-            },
+    let h = variadic_help(
+        "+",
+        "concatenate rows of table",
+        vec![
             HelpExample {
                 desc: "add two tables together, concatenating rows",
                 code: "range 0 10 | + range 10 20",
@@ -147,7 +88,18 @@ if input is a Table, concat or join additional tables
                 code: "range 0 1000 | + --cols --intersect ls",
             },
         ],
-        ..HelpMessage::new("+")
+    );
+
+    HelpMessage {
+        flags: vec![
+            ("cols", "join tables (append columns)"),
+            ("union", "expand table to capture all data (default)"),
+            (
+                "intersect",
+                "use minimum size of table; min rows for --cols, min cols for concat rows",
+            ),
+        ],
+        ..h
     }
 }
 

--- a/ogma/src/lang/impls/intrinsics/arithmetic.rs
+++ b/ogma/src/lang/impls/intrinsics/arithmetic.rs
@@ -3,11 +3,11 @@ use std::cmp;
 
 pub fn add_intrinsics(impls: &mut Implementations) {
     add! { impls,
-        (+, add, Arithmetic)
-        (*, mul, Arithmetic)
+        ("+", add, Arithmetic)
+        ("*", mul, Arithmetic)
         ("×", mul, Arithmetic)
         ("-", sub, Arithmetic)
-        (/, div, Arithmetic)
+        ("/", div, Arithmetic)
         ("÷", div, Arithmetic)
         (ceil, Arithmetic)
         (floor, Arithmetic)

--- a/ogma/src/lang/impls/intrinsics/mod.rs
+++ b/ogma/src/lang/impls/intrinsics/mod.rs
@@ -13,19 +13,23 @@ use std::{
 use Type as Ty;
 
 macro_rules! add {
+    // untyped
     ($impls:expr, ($cmd:tt, $cat:ident) $($rem:tt)*) => {{
-        add!($impls, ($cmd, $cmd, $cat) $($rem)*)
+        add!($impls, (stringify!($cmd), $cmd, $cat) $($rem)*)
     }};
-    ($impls:expr, ($cmd:literal, $inner:tt, $cat:ident) $($rem:tt)*) => {{
-        paste! { add!($impls, ($cmd, [<$inner _intrinsic>], $cat, [<$inner _help>]) $($rem)*) }
+    ($impls:expr, ($cmd:expr, $inner:tt, $cat:ident) $($rem:tt)*) => {{
+        paste! { add!($impls, ($cmd, None, [<$inner _intrinsic>], $cat, [<$inner _help>]) $($rem)*) }
     }};
-    ($impls:expr, ($cmd:tt, $inner:tt, $cat:ident) $($rem:tt)*) => {{
-        paste! { add!($impls, (stringify!($cmd), [<$inner _intrinsic>], $cat, [<$inner _help>]) $($rem)*) }
+    // typed
+    ($impls:expr, ($cmd:literal, $type:ty, $inner:tt, $cat:ident) $($rem:tt)*) => {{
+        let t = Some(<$type as AsType>::as_type());
+        paste! { add!($impls, ($cmd, t, [<$inner _intrinsic>], $cat, [<$inner _help>]) $($rem)*) }
     }};
-    ($impls:expr, ($cmd:expr, $fn:path, $cat:ident, $help:path) $($rem:tt)* ) => {{
+    // agnostic
+    ($impls:expr, ($cmd:expr, $in_ty:expr, $fn:path, $cat:ident, $help:path) $($rem:tt)* ) => {{
         $impls.insert_intrinsic(
             $cmd,
-            None,
+            $in_ty,
             $fn,
             Location::Ogma,
             OperationCategory::$cat,

--- a/ogma/src/lang/impls/intrinsics/pipeline.rs
+++ b/ogma/src/lang/impls/intrinsics/pipeline.rs
@@ -6,6 +6,7 @@ pub fn add_intrinsics(impls: &mut Implementations) {
         (get, Pipeline)
         (
             ".",
+            None,
             ast::DotOperatorBlock::instrinsic,
             Pipeline,
             ast::DotOperatorBlock::help
@@ -16,9 +17,9 @@ pub fn add_intrinsics(impls: &mut Implementations) {
         (nth, Pipeline)
         (rand, Pipeline)
         (range, Pipeline)
-        (Table, table, Pipeline)
+        ("Table", table, Pipeline)
         ("to-str", to_str, Pipeline)
-        (Tuple, tuple, Pipeline)
+        ("Tuple", tuple, Pipeline)
     };
 }
 

--- a/ogma/src/lang/impls/mod.rs
+++ b/ogma/src/lang/impls/mod.rs
@@ -53,57 +53,118 @@ impl fmt::Display for OperationCategory {
     }
 }
 
+type Impl = (Implementation, OperationCategory, HelpMessage);
+
 #[derive(Clone)]
-pub struct Implementations {
-    /// Impls are the (name, in_ty)
-    impls: HashMap<(Str, Option<Type>), Implementation>,
-    names: HashMap<Str, (OperationCategory, HelpMessage)>,
+// Structure is a nested map of maps, first by the command name, then by the input type.
+pub struct Implementations(HashMap<Str, Keys>);
+
+#[derive(Clone, Default)]
+struct Keys {
+    tys: HashMap<Type, Impl>,
+    agnostic: Option<Impl>,
+}
+
+impl Keys {
+    /// Get the [`Impl`] keyed on `ty`. If none are present, tries to get an impl keyed on `None`.
+    fn get_impl(&self, ty: &Type) -> Option<&Impl> {
+        self.tys.get(ty).or_else(|| self.agnostic.as_ref())
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (Option<&Type>, &Impl)> {
+        self.tys
+            .iter()
+            .map(|(t, x)| (Some(t), x))
+            .chain(self.agnostic.iter().map(|x| (None, x)))
+    }
+
+    fn retain<F>(&mut self, mut predicate: F)
+    where
+        F: FnMut(Option<&Type>, &Implementation, &OperationCategory, &HelpMessage) -> bool,
+    {
+        self.tys.retain(|t, (i, o, h)| predicate(Some(t), i, o, h));
+        self.agnostic = self
+            .agnostic
+            .take()
+            .filter(|(i, o, h)| predicate(None, i, o, h));
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tys.is_empty() && self.agnostic.is_none()
+    }
 }
 
 impl Default for Implementations {
     fn default() -> Self {
-        let mut impls = Implementations {
-            impls: HashMap::default(),
-            names: HashMap::default(),
-        };
-
+        let mut impls = Implementations(HashMap::default());
         intrinsics::add_intrinsics(&mut impls);
-
         impls
     }
 }
 
+pub struct ImplEntry<'a> {
+    pub name: &'a Str,
+    /// The input type this is keyed on.
+    pub ty: Option<&'a Type>,
+    pub cat: OperationCategory,
+    pub help: &'a HelpMessage,
+    pub impl_: &'a Implementation,
+}
+
 impl Implementations {
-    pub fn contains_op(&self, op: &str) -> bool {
-        self.names.contains_key(op)
+    /// Is there an op with `name`?
+    pub fn contains_op(&self, name: &str) -> bool {
+        self.0.contains_key(name)
     }
 
-    pub fn get_help(&self, op: &Tag) -> Result<&HelpMessage> {
-        if !self.contains_op(op.str()) {
-            return Err(Error::op_not_found(op, None, false, self));
-        }
-
-        Ok(&self.names.get(op.str()).expect("checked was in").1)
+    /// Gets the specific help message of a command given the input type.
+    pub fn get_help(&self, op: &str, ty: &Type) -> Option<&HelpMessage> {
+        self.0.get(op)?.get_impl(ty).map(|x| &x.2)
     }
 
-    pub fn get_cat(&self, op: &str) -> Option<OperationCategory> {
-        self.names.get(op).map(|x| x.0)
+    /// **Builds** the help message which concatenates all applicable input types.
+    pub fn get_help_all(&self, op: &str) -> Option<Error> {
+        let mut xs = self
+            .0
+            .get(op)?
+            .iter()
+            .map(|(t, (_, _, x))| (t, x))
+            .collect::<Vec<_>>();
+        xs.sort_unstable_by_key(|a| a.0.map(ToString::to_string));
+
+        xs.into_iter()
+            .map(|(t, x)| err::help_as_error(x, t))
+            .reduce(|mut acc, x| {
+                if let Some((a, b)) = acc.traces.get_mut(0).zip(x.traces.get(0)) {
+                    a.source += "\n";
+                    a.source += &b.source;
+                }
+                acc
+            })
     }
 
-    pub fn get_impl(&self, op: &Tag, ty: &Type) -> Result<&Implementation> {
-        if !self.contains_op(op.str()) {
-            return Err(Error::op_not_found(op, Some(ty), false, self));
-        }
+    /// **Builds** the help message which concatenates all applicable input types.
+    /// If `op` is not found, returns an error.
+    pub fn get_help_with_err(&self, op: &Tag) -> Result<Error> {
+        self.get_help_all(op.str())
+            .ok_or_else(|| Error::op_not_found(op, None, false, self))
+    }
 
-        let mut key = (Str::new(op), Some(ty.clone()));
-        let mut r = self.impls.get(&key); // first try to get impl which matches input type `ty`
-        if r.is_none() {
-            // if none found, try finding an impl with no ty
-            key.1 = None;
-            r = self.impls.get(&key);
-        }
+    /// Find the appropriate [`Implementation`] for the command `op` with the input `ty`pe.
+    /// This will _fallback_ to commands which have agnostic input types if no specific
+    /// implementation is found.
+    pub fn get_impl(&self, op: &str, ty: &Type) -> Option<&Implementation> {
+        self.0.get(op)?.get_impl(ty).map(|x| &x.0)
+    }
 
-        r.ok_or_else(|| Error::impl_not_found(op, ty))
+    /// Helper which is the same as [`Self::get_impl`] but creates an [`Error`] upon failure.
+    pub fn get_impl_with_err(&self, op: &Tag, ty: &Type) -> Result<&Implementation> {
+        match self.contains_op(op.str()) {
+            true => self
+                .get_impl(op.str(), ty)
+                .ok_or_else(|| Error::impl_not_found(op, ty)),
+            false => Err(Error::op_not_found(op, Some(ty), false, self)),
+        }
     }
 
     fn insert_intrinsic<O, I, F>(
@@ -120,14 +181,28 @@ impl Implementations {
         F: Fn(Block) -> Result<Step> + Send + Sync + 'static,
     {
         let name = op.into();
-        self.impls.insert(
-            (name.clone(), in_ty.into()),
+        let keys = self.0.entry(name).or_default();
+
+        let impl_ = (
             Implementation::Intrinsic {
                 loc,
                 f: Arc::new(f),
             },
+            cat,
+            help,
         );
-        self.names.insert(name, (cat, help));
+        let _not_overwritten = match in_ty.into() {
+            Some(t) => keys.tys.insert(t, impl_).is_none(),
+            None => {
+                let x = keys.agnostic.is_none();
+                keys.agnostic = Some(impl_);
+                x
+            }
+        };
+        debug_assert!(
+            _not_overwritten,
+            "intrinsics should not overwrite one another"
+        );
     }
 
     pub fn insert_impl<I>(
@@ -140,45 +215,75 @@ impl Implementations {
     where
         I: Into<Option<Type>>,
     {
-        let name = Str::new(&def.name);
-        let key = (name.clone(), in_ty.into());
-        if let Some(im) = self.impls.get(&key) {
-            // we check that the impl does not conflict with ogma defined ones
-            let ogma_defined = match im {
+        let name = def.name.str();
+        let ty = in_ty.into();
+        // we check that the impl does not conflict with ogma defined ones
+        let ogma_defined = self
+            .0
+            .get(name)
+            .and_then(|x| match &ty {
+                Some(t) => x.tys.get(t),
+                None => x.agnostic.as_ref(),
+            })
+            .map(|(im, _, _)| im)
+            .filter(|im| match im {
                 Implementation::Intrinsic { .. } => true,
                 Implementation::Definition(x) if x.loc == Location::Ogma => true,
                 _ => false,
-            };
-            if ogma_defined {
-                return Err(Error::predefined_impl(&def, key.1.as_ref()));
-            }
+            })
+            .is_some();
+
+        if ogma_defined {
+            return Err(Error::predefined_impl(&def, ty.as_ref()));
         }
 
-        self.impls
-            .insert(key, Implementation::Definition(Box::new(def)));
-        self.names.insert(name, (cat, help));
+        let name = Str::new(name);
+
+        let keys = self.0.entry(name).or_default();
+        let impl_ = (Implementation::Definition(Box::new(def)), cat, help);
+
+        match ty {
+            Some(t) => {
+                keys.tys.insert(t, impl_);
+            }
+            None => keys.agnostic = Some(impl_),
+        }
 
         Ok(())
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&Str, Option<&Type>, &Implementation)> {
-        self.impls
-            .iter()
-            .map(|((name, ty), im)| (name, ty.as_ref(), im))
+    /// Iterate over _all_ the implementations.
+    pub fn iter(&self) -> impl Iterator<Item = ImplEntry> {
+        self.0.keys().flat_map(|name| self.iter_op(name))
     }
 
-    pub fn help_iter(&self) -> impl Iterator<Item = (&Str, &HelpMessage)> {
-        self.names.iter().map(|(name, (_, help))| (name, help))
+    /// Iterate over _all_ the implementations for `op`.
+    pub fn iter_op<'a>(&'a self, op: &str) -> impl Iterator<Item = ImplEntry<'a>> {
+        self.0
+            .get_key_value(op)
+            .into_iter()
+            .flat_map(|(name, map)| {
+                map.iter().map(|(ty, (impl_, cat, help))| ImplEntry {
+                    name,
+                    ty,
+                    cat: *cat,
+                    help,
+                    impl_,
+                })
+            })
     }
 
+    /// Remove any loaded implementations, reducing the implementations down to what is defined in
+    /// `ogma`. If `only_files` is `true`, items defined in the shell are retained.
     pub fn clear(&mut self, only_files: bool) {
-        self.impls.retain(|_, im| match im.location() {
-            Location::Ogma => true,
-            Location::Shell => only_files,
-            Location::File(_, _) => false,
+        self.0.values_mut().for_each(|m| {
+            m.retain(|_, im, _, _| match im.location() {
+                Location::Ogma => true,
+                Location::Shell => only_files,
+                Location::File(_, _) => false,
+            })
         });
-        let names = self.impls.keys().map(|k| &k.0).collect::<HashSet<_>>();
-        self.names.retain(|k, _| names.contains(k));
+        self.0.retain(|_, m| !m.is_empty())
     }
 }
 

--- a/ogma/src/lang/impls/mod.rs
+++ b/ogma/src/lang/impls/mod.rs
@@ -102,12 +102,17 @@ impl Default for Implementations {
     }
 }
 
+/// An implementation entry.
 pub struct ImplEntry<'a> {
+    /// The command/op name.
     pub name: &'a Str,
     /// The input type this is keyed on.
     pub ty: Option<&'a Type>,
+    /// Command category.
     pub cat: OperationCategory,
+    /// Command help.
     pub help: &'a HelpMessage,
+    /// The implementation.
     pub impl_: &'a Implementation,
 }
 

--- a/ogma/src/lang/impls/mod.rs
+++ b/ogma/src/lang/impls/mod.rs
@@ -68,7 +68,7 @@ struct Keys {
 impl Keys {
     /// Get the [`Impl`] keyed on `ty`. If none are present, tries to get an impl keyed on `None`.
     fn get_impl(&self, ty: &Type) -> Option<&Impl> {
-        self.tys.get(ty).or_else(|| self.agnostic.as_ref())
+        self.tys.get(ty).or(self.agnostic.as_ref())
     }
 
     fn iter(&self) -> impl Iterator<Item = (Option<&Type>, &Impl)> {

--- a/ogma/src/lang/mod.rs
+++ b/ogma/src/lang/mod.rs
@@ -9,5 +9,6 @@ pub(crate) mod types;
 // Public API
 
 pub use defs::{construct_def_table, process_definition, recognise_definition, Definitions};
+pub use impls::ImplEntry;
 pub use syntax::{ast, parse};
 pub use types::{AsType, OgmaData, Table, Type, Value};

--- a/ogma/src/lang/types.rs
+++ b/ogma/src/lang/types.rs
@@ -955,7 +955,7 @@ mod tests {
     }
 
     fn x(t: Type) -> String {
-        t.help().to_string()
+        crate::common::err::help_as_error(&t.help(), None).to_string()
     }
 
     #[test]

--- a/ogma/src/lang/types.rs
+++ b/ogma/src/lang/types.rs
@@ -964,6 +964,7 @@ mod tests {
             &x(Nil),
             "Help: `Nil`
 --> shell:0
+ | ---- Input Type: <any> ----
  | nothing value
  | 
  | Usage:
@@ -974,6 +975,7 @@ mod tests {
             &x(Bool),
             "Help: `Bool`
 --> shell:0
+ | ---- Input Type: <any> ----
  | boolean value
  | true | false
  | 
@@ -985,6 +987,7 @@ mod tests {
             &x(Num),
             "Help: `Number`
 --> shell:0
+ | ---- Input Type: <any> ----
  | number value
  | 100 | -1 | 3.14 | -1.23e-5
  | 
@@ -996,6 +999,7 @@ mod tests {
             &x(Str),
             "Help: `String`
 --> shell:0
+ | ---- Input Type: <any> ----
  | string value
  | 
  | Usage:
@@ -1006,6 +1010,7 @@ mod tests {
             &x(Tab),
             "Help: `Table`
 --> shell:0
+ | ---- Input Type: <any> ----
  | table value
  | 
  | Usage:
@@ -1016,6 +1021,7 @@ mod tests {
             &x(TabRow),
             "Help: `TableRow`
 --> shell:0
+ | ---- Input Type: <any> ----
  | table row
  | 
  | Usage:
@@ -1030,6 +1036,7 @@ mod tests {
             &x(Def(ORD.get())),
             "Help: `Ord`
 --> shell:0
+ | ---- Input Type: <any> ----
  | <ogma>
  | `def-ty Ord :: Lt | Eq | Gt`
  | 

--- a/ogma/src/rt/process.rs
+++ b/ogma/src/rt/process.rs
@@ -34,13 +34,14 @@ where
 /// Check if an expression has a help flag and output the help message (as the `Err` variant).
 pub fn handle_help(expr: &ast::Expression, definitions: &Definitions) -> Result<()> {
     if let Some(block) = expr.blocks.get(0) {
-        let help = definitions.impls().get_help(&block.op())?;
-        if block
+        let help_flagged = block
             .terms()
             .iter()
-            .any(|x| matches!(x, ast::Term::Flag(f) if f.str() == "help"))
-        {
-            Err(err::help_as_error(help))
+            .any(|x| matches!(x, ast::Term::Flag(f) if f.str() == "help"));
+
+        if help_flagged {
+            let x = definitions.impls().get_help_with_err(&block.op())?;
+            Err(x)
         } else {
             Ok(())
         }

--- a/ogma/tests/commands/arithmetic.rs
+++ b/ogma/tests/commands/arithmetic.rs
@@ -9,6 +9,7 @@ fn abs_help_msg() {
         &x,
         "Help: `abs`
 --> shell:0
+ | ---- Input Type: Number ----
  | user defined implementation in <ogma>
  | `def abs Num () { if {< 0} {* -1} #i }`
  | take the absolute of a number
@@ -307,6 +308,7 @@ fn ceil_help_msg() {
         &x,
         "Help: `ceil`
 --> shell:0
+ | ---- Input Type: <any> ----
  | return the smallest integer greater than or equal to a number
  | 
  | Usage:
@@ -323,6 +325,7 @@ fn floor_help_msg() {
         &x,
         "Help: `floor`
 --> shell:0
+ | ---- Input Type: <any> ----
  | return the largest integer less than or equal to a number
  | 
  | Usage:
@@ -353,6 +356,7 @@ fn div_help_msg() {
         &x,
         "Help: `/`
 --> shell:0
+ | ---- Input Type: <any> ----
  | divide arguments against one another
  | note: if input is not a Num, the first arg is used as lhs
  | dividing by 0 will result in infinity (∞)
@@ -396,6 +400,7 @@ fn isfinite_help_msg() {
         &x,
         "Help: `is-finite`
 --> shell:0
+ | ---- Input Type: <any> ----
  | returns whether a number is finite
  | a number is finite if it is not infinite AND not NaN
  | 
@@ -436,6 +441,7 @@ fn mod_help_msg() {
         &x,
         "Help: `mod`
 --> shell:0
+ | ---- Input Type: Number ----
  | user defined implementation in <ogma>
  | `def mod Num (denom) { - {/ $denom | floor | * $denom} }`
  | return the modulus of a number
@@ -468,6 +474,7 @@ fn mul_help_msg() {
         &x,
         "Help: `*`
 --> shell:0
+ | ---- Input Type: <any> ----
  | multiply arguments together
  | -variadic-: more than one argument can be specified
  | 
@@ -504,6 +511,7 @@ fn root_help_msg() {
         &x,
         "Help: `root`
 --> shell:0
+ | ---- Input Type: <any> ----
  | calculate the nth root of a number
  | 
  | Usage:
@@ -539,6 +547,7 @@ fn sub_help_msg() {
         &x,
         "Help: `-`
 --> shell:0
+ | ---- Input Type: <any> ----
  | subtract arguments from one another
  | note: if input is not a Num, the first arg is used as lhs
  | -variadic-: more than one argument can be specified

--- a/ogma/tests/commands/arithmetic.rs
+++ b/ogma/tests/commands/arithmetic.rs
@@ -35,10 +35,38 @@ fn add_help_msg() {
     let x = print_help(src, &Definitions::new());
     assert_eq!(
         &x,
-        "Help: `+`
+        r#"Help: `+`
 --> shell:0
- | add arguments together
- | if input is a Table, concat or join additional tables
+ | ---- Input Type: Number ----
+ | add numbers together
+ | -variadic-: more than one argument can be specified
+ | 
+ | Usage:
+ |  => + args..
+ | 
+ | Examples:
+ |  add 2 to 1
+ |  => \ 1 | + 2
+ | 
+ |  add multiple numbers together
+ |  => + 1 2 3 4 5
+ | 
+ | ---- Input Type: String ----
+ | concatenate strings together
+ | -variadic-: more than one argument can be specified
+ | 
+ | Usage:
+ |  => + args..
+ | 
+ | Examples:
+ |  join together strings
+ |  => \ Hello | + ', world!'
+ | 
+ |  join strings with a new line
+ |  => \ 'First Line' | + #b 'Second Line'
+ | 
+ | ---- Input Type: Table ----
+ | concatenate rows of table
  | -variadic-: more than one argument can be specified
  | 
  | Usage:
@@ -50,18 +78,12 @@ fn add_help_msg() {
  |  --intersect: use minimum size of table; min rows for --cols, min cols for concat rows
  | 
  | Examples:
- |  add 2 to 1
- |  => \\ 1 | + 2
- | 
- |  add multiple numbers together
- |  => + 1 2 3 4 5
- | 
  |  add two tables together, concatenating rows
  |  => range 0 10 | + range 10 20
  | 
  |  index filesystem items, shrink table to min rows
  |  => range 0 1000 | + --cols --intersect ls
-"
+"#
     );
 }
 

--- a/ogma/tests/commands/cmp.rs
+++ b/ogma/tests/commands/cmp.rs
@@ -9,6 +9,7 @@ fn cmp_help_test() {
         &x,
         "Help: `cmp`
 --> shell:0
+ | ---- Input Type: <any> ----
  | compare <rhs> to input
  | 
  | Usage:
@@ -31,6 +32,7 @@ fn ord_init_help_test() {
         &x,
         "Help: `Ord`
 --> shell:0
+ | ---- Input Type: <any> ----
  | initialise a `Ord`
  | 
  | Usage:
@@ -162,6 +164,7 @@ fn eq_help_test() {
         &x,
         "Help: `eq`
 --> shell:0
+ | ---- Input Type: <any> ----
  | returns if <rhs> is equal to input
  | 
  | Usage:
@@ -232,6 +235,7 @@ fn gt_help_msg() {
         &x,
         "Help: `>`
 --> shell:0
+ | ---- Input Type: <any> ----
  | user defined implementation in <ogma>
  | `def > (rhs) { cmp $rhs | = Ord::Gt }`
  | test if input is greater than rhs
@@ -269,6 +273,7 @@ fn min_help_msg() {
         &x,
         "Help: `min`
 --> shell:0
+ | ---- Input Type: <any> ----
  | return the minimum value
  | -variadic-: more than one argument can be specified
  | 
@@ -293,6 +298,7 @@ fn max_help_msg() {
         &x,
         "Help: `max`
 --> shell:0
+ | ---- Input Type: <any> ----
  | return the maximum value
  | -variadic-: more than one argument can be specified
  | 

--- a/ogma/tests/commands/definitions.rs
+++ b/ogma/tests/commands/definitions.rs
@@ -111,21 +111,21 @@ fn list_defs() {
 
         assert_eq!(
             s,
-            "┌────────────────┬─────────────┬───────┬──────────┬──────┬────────────────────────────┐
-│ name           ┆ category    ┆ input ┆ location ┆ line ┆ code                       │
-╞════════════════╪═════════════╪═══════╪══════════╪══════╪════════════════════════════╡
-│ !=             ┆ cmp         ┆ -     ┆ <ogma>   ┆ -    ┆ != (rhs) { eq $rhs | not } │
-│ *              ┆ arithmetic  ┆ -     ┆ <ogma>   ┆ -    ┆ -                          │
-│ +              ┆ arithmetic  ┆ -     ┆ <ogma>   ┆ -    ┆ -                          │
-│ -              ┆ arithmetic  ┆ -     ┆ <ogma>   ┆ -    ┆ -                          │
-│ .              ┆ pipeline    ┆ -     ┆ <ogma>   ┆ -    ┆ -                          │
-│ 61 rows elided ┆ ...         ┆ ...   ┆ ...      ┆ ...  ┆ ...                        │
-│ take           ┆ morphism    ┆ -     ┆ <ogma>   ┆ -    ┆ -                          │
-│ to-str         ┆ pipeline    ┆ -     ┆ <ogma>   ┆ -    ┆ -                          │
-│ typify         ┆ diagnostics ┆ -     ┆ <ogma>   ┆ -    ┆ -                          │
-│ ×              ┆ arithmetic  ┆ -     ┆ <ogma>   ┆ -    ┆ -                          │
-│ ÷              ┆ arithmetic  ┆ -     ┆ <ogma>   ┆ -    ┆ -                          │
-└────────────────┴─────────────┴───────┴──────────┴──────┴────────────────────────────┘
+            "┌────────────────┬─────────────┬────────┬──────────┬──────┬────────────────────────────┐
+│ name           ┆ category    ┆ input  ┆ location ┆ line ┆ code                       │
+╞════════════════╪═════════════╪════════╪══════════╪══════╪════════════════════════════╡
+│ !=             ┆ cmp         ┆ -      ┆ <ogma>   ┆ -    ┆ != (rhs) { eq $rhs | not } │
+│ *              ┆ arithmetic  ┆ -      ┆ <ogma>   ┆ -    ┆ -                          │
+│ +              ┆ arithmetic  ┆ Number ┆ <ogma>   ┆ -    ┆ -                          │
+│ +              ┆ arithmetic  ┆ String ┆ <ogma>   ┆ -    ┆ -                          │
+│ +              ┆ arithmetic  ┆ Table  ┆ <ogma>   ┆ -    ┆ -                          │
+│ 63 rows elided ┆ ...         ┆ ...    ┆ ...      ┆ ...  ┆ ...                        │
+│ take           ┆ morphism    ┆ -      ┆ <ogma>   ┆ -    ┆ -                          │
+│ to-str         ┆ pipeline    ┆ -      ┆ <ogma>   ┆ -    ┆ -                          │
+│ typify         ┆ diagnostics ┆ -      ┆ <ogma>   ┆ -    ┆ -                          │
+│ ×              ┆ arithmetic  ┆ -      ┆ <ogma>   ┆ -    ┆ -                          │
+│ ÷              ┆ arithmetic  ┆ -      ┆ <ogma>   ┆ -    ┆ -                          │
+└────────────────┴─────────────┴────────┴──────────┴──────┴────────────────────────────┘
 "
         );
     } else {

--- a/ogma/tests/commands/definitions.rs
+++ b/ogma/tests/commands/definitions.rs
@@ -13,6 +13,7 @@ fn defs_help_msg() {
         &x,
         "Help: `def`
 --> shell:0
+ | ---- Input Type: <any> ----
  | define a command that encapsulates an expression
  | def has specialised syntax which takes variable params: ( )
  | 
@@ -47,6 +48,7 @@ fn user_def_help_msg() {
         &x,
         "Help: `num5`
 --> shell:0
+ | ---- Input Type: <any> ----
  | user defined implementation in shell
  | `def num5 () { \\ 5 }`
  | 
@@ -61,6 +63,7 @@ fn user_def_help_msg() {
         &x,
         "Help: `gt10`
 --> shell:0
+ | ---- Input Type: <any> ----
  | user defined implementation in 'some/file' - line 12
  | `def gt10 (n) { get $n | > 10 }`
  | 
@@ -182,6 +185,7 @@ def z2 () { ls }";
         &x,
         "Help: `z2`
 --> shell:0
+ | ---- Input Type: <any> ----
  | user defined implementation in 'hello' - line 6
  | `def z2 () { ls }`
  | 
@@ -266,6 +270,7 @@ def bar () {
         &x,
         "Help: `zog`
 --> shell:0
+ | ---- Input Type: Number ----
  | user defined implementation in 'foo' - line 4
  | `def zog Num (x y) {
  |     + $x |
@@ -289,6 +294,7 @@ def bar () {
         &x,
         "Help: `bar`
 --> shell:0
+ | ---- Input Type: <any> ----
  | user defined implementation in 'foo' - line 18
  | `def bar () {
  |     if {= foo}

--- a/ogma/tests/commands/diagnostics.rs
+++ b/ogma/tests/commands/diagnostics.rs
@@ -9,6 +9,7 @@ fn benchmark_help_msg() {
         &x,
         "Help: `benchmark`
 --> shell:0
+ | ---- Input Type: <any> ----
  | time the expression evaluation
  | pipes <input> to <expr>
  | 
@@ -51,6 +52,7 @@ fn typify_help_msg() {
         &x,
         "Help: `typify`
 --> shell:0
+ | ---- Input Type: <any> ----
  | output an expanded, type annotated, string of the argument
  | 
  | Usage:

--- a/ogma/tests/commands/io.rs
+++ b/ogma/tests/commands/io.rs
@@ -9,6 +9,7 @@ fn ls_help_msg() {
         &x,
         "Help: `ls`
 --> shell:0
+ | ---- Input Type: <any> ----
  | list out aspects of the input
  | input is Nil; outputs the filesystem contents in the current working dir
  | input is Table; outputs the headers as a table

--- a/ogma/tests/commands/logic.rs
+++ b/ogma/tests/commands/logic.rs
@@ -9,6 +9,7 @@ fn and_help_msg() {
         &x,
         "Help: `and`
 --> shell:0
+ | ---- Input Type: <any> ----
  | returns true if all arguments are true
  | -variadic-: more than one argument can be specified
  | 
@@ -50,6 +51,7 @@ fn if_help_msg() {
         &x,
         "Help: `if`
 --> shell:0
+ | ---- Input Type: <any> ----
  | evaluate expression if predicate is met
  | input is carried through to each of the expressions
  | `expr-if-true` and `expr-if-false` must evaluate to the same type
@@ -142,6 +144,7 @@ fn or_help_msg() {
         &x,
         "Help: `or`
 --> shell:0
+ | ---- Input Type: <any> ----
  | returns true if any arguments are true
  | -variadic-: more than one argument can be specified
  | 

--- a/ogma/tests/commands/morphism.rs
+++ b/ogma/tests/commands/morphism.rs
@@ -9,6 +9,7 @@ fn append_help_msg() {
         &x,
         "Help: `append`
 --> shell:0
+ | ---- Input Type: <any> ----
  | add new columns onto a table using one or more expressions
  | each expression adds a new column, populated by row with the result of the expression
  | tags can be optionally specified to name the columns
@@ -95,6 +96,7 @@ fn append_row_help_msg() {
         &x,
         "Help: `append-row`
 --> shell:0
+ | ---- Input Type: <any> ----
  | append a row to the table
  | the row is populated with the expression results
  | -variadic-: more than one argument can be specified
@@ -153,6 +155,7 @@ fn dedup_help_msg() {
         &x,
         "Help: `dedup`
 --> shell:0
+ | ---- Input Type: <any> ----
  | deduplicate items
  | for Tables consectutive repeated rows are removed if the cells in
  | specified columns match. if no columns are specified the whole row must match.
@@ -246,6 +249,7 @@ fn filtering_help_msg() {
         &x,
         "Help: `filter`
 --> shell:0
+ | ---- Input Type: <any> ----
  | filter incoming data using a predicate
  | filter can be used with a column header and a type flag
  | filtering columns is achievable with the --cols flag
@@ -421,6 +425,7 @@ fn fold_help_msg() {
         &x,
         "Help: `fold`
 --> shell:0
+ | ---- Input Type: <any> ----
  | fold (reduce) table into single value
  | fold takes a seed value and an accumulator expression
  | the variable $row is available to query the table row
@@ -457,6 +462,7 @@ fn fold_while_help_msg() {
         &x,
         "Help: `fold-while`
 --> shell:0
+ | ---- Input Type: <any> ----
  | fold (reduce) table into single value while a predicate remains true
  | fold-while is similar to fold with an added predicate check on each iteration
  | the input into the predicate is the current accumulator value
@@ -494,6 +500,7 @@ fn grp_help_msg() {
         &x,
         "Help: `grp`
 --> shell:0
+ | ---- Input Type: <any> ----
  | group a table by column headers
  | each value under the header is stringified and
  | concatenated together separated by a hyphen
@@ -557,6 +564,7 @@ fn grpby_help_msg() {
         &x,
         "Help: `grp-by`
 --> shell:0
+ | ---- Input Type: <any> ----
  | group table using an expression
  | the result of the expression must define a `cmp` implementation
  | this can be used to group user-defined types
@@ -603,6 +611,7 @@ fn map_help_msg() {
         &x,
         "Help: `map`
 --> shell:0
+ | ---- Input Type: <any> ----
  | replace entry in column with result of an expression
  | `map` provides the variable `$row` which is the TableRow
  | the input into the expression is the value of the entry
@@ -697,6 +706,7 @@ fn pick_help_msg() {
         &x,
         "Help: `pick`
 --> shell:0
+ | ---- Input Type: <any> ----
  | pick out columns to keep in a table, in order
  | 
  | Usage:
@@ -816,6 +826,7 @@ fn ren_help_msg() {
         &x,
         "Help: `ren`
 --> shell:0
+ | ---- Input Type: <any> ----
  | rename column headers
  | each binding takes the form `<col-ref> <name>`
  | `<col-ref>` can be a string or a column index number
@@ -903,6 +914,7 @@ fn ren_with_help_msg() {
         &x,
         "Help: `ren-with`
 --> shell:0
+ | ---- Input Type: <any> ----
  | rename column headers using a row as a seed
  | each entry is fed into the expression, which returns a string
  | the default entry type required is a string
@@ -1010,6 +1022,7 @@ fn rev_help_msg() {
         &x,
         "Help: `rev`
 --> shell:0
+ | ---- Input Type: <any> ----
  | reverse the order of the input
  | for String inputs; character ordering is reversed
  | for Table inputs; row or col ordering is reversed
@@ -1074,6 +1087,7 @@ fn skip_help_msg() {
         &x,
         "Help: `skip`
 --> shell:0
+ | ---- Input Type: <any> ----
  | skip the first n elements of a data structure
  | 
  | Usage:
@@ -1141,6 +1155,7 @@ fn sort_help_msg() {
         &x,
         "Help: `sort`
 --> shell:0
+ | ---- Input Type: <any> ----
  | sort a table by column headers
  | each header sorts the rows lowest to highest in a canonical fashion,
  | in order specified (1st column is sorted first)
@@ -1206,6 +1221,7 @@ fn sortby_help_msg() {
         &x,
         "Help: `sort-by`
 --> shell:0
+ | ---- Input Type: <any> ----
  | sort table using an expression
  | the result of the expression must define a `cmp` implementation
  | this can be used to sort user-defined types
@@ -1353,6 +1369,7 @@ fn take_help_msg() {
         &x,
         "Help: `take`
 --> shell:0
+ | ---- Input Type: <any> ----
  | take the first n elements of a data structure
  | 
  | Usage:

--- a/ogma/tests/commands/pipeline.rs
+++ b/ogma/tests/commands/pipeline.rs
@@ -9,6 +9,7 @@ fn dotop_help_msg() {
         &x,
         "Help: `.`
 --> shell:0
+ | ---- Input Type: <any> ----
  | extract a value out of a structure using an infix operator
  | 
  | Usage:
@@ -240,6 +241,7 @@ fn get_help_msg() {
         &x,
         "Help: `get`
 --> shell:0
+ | ---- Input Type: <any> ----
  | extract a value out of a data structure
  | optionally specify a default value if the get type does not match
  | 
@@ -327,6 +329,7 @@ fn input_help_msg() {
         &x,
         "Help: `\\`
 --> shell:0
+ | ---- Input Type: <any> ----
  | sets the input value for the next pipeline block
  | 
  | Usage:
@@ -420,6 +423,7 @@ fn len_help_msg() {
         &x,
         "Help: `len`
 --> shell:0
+ | ---- Input Type: <any> ----
  | return the length of a table or string (chars)
  | table length **does not include header row**
  | 
@@ -471,6 +475,7 @@ fn let_help_msg() {
         &x,
         "Help: `let`
 --> shell:0
+ | ---- Input Type: <any> ----
  | assign variable identifiers to expression results
  | each binding takes the form `<expr> $var`
  | optionally a final `$var` can be specified which assigns the input
@@ -703,6 +708,7 @@ fn nth_help_msg() {
         &x,
         "Help: `nth`
 --> shell:0
+ | ---- Input Type: <any> ----
  | retrieve the nth element of a data structure
  | String: retrieves the nth character
  | Table: retrieves the nth row and applies the expression
@@ -810,6 +816,7 @@ fn rand_help_msg() {
         &x,
         "Help: `rand`
 --> shell:0
+ | ---- Input Type: <any> ----
  | return a random number
  | rand has four ways of calling:
  | 1. Without arguments: this returns a number (0,1],
@@ -876,6 +883,7 @@ fn range_help_msg() {
         &x,
         "Help: `range`
 --> shell:0
+ | ---- Input Type: <any> ----
  | create a single column table of integers (from,to]
  | `from` is inclusive, `to` is exclusive
  | `to` can be omitted if input is a number
@@ -938,6 +946,7 @@ fn to_str_help_msg() {
         &x,
         "Help: `to-str`
 --> shell:0
+ | ---- Input Type: <any> ----
  | convert the input into a string
  | 
  | Usage:

--- a/ogma/tests/commands/types.rs
+++ b/ogma/tests/commands/types.rs
@@ -82,6 +82,7 @@ fn table_help_msg() {
         &x,
         "Help: `Table`
 --> shell:0
+ | ---- Input Type: <any> ----
  | create an empty table with the given table headers
  | -variadic-: more than one argument can be specified
  | 
@@ -122,6 +123,7 @@ fn tuple_help_msg() {
         &x,
         "Help: `Tuple`
 --> shell:0
+ | ---- Input Type: <any> ----
  | construct a tuple of the result of each expression
  | tuples impl `eq` and `cmp` if all its fields also implement `eq` and `cmp`
  | tuples have unique types: `U_<t0_Ty>-<t1_Ty>_`
@@ -300,6 +302,7 @@ fn point_construction_help() {
         &x,
         "Help: `Point`
 --> shell:0
+ | ---- Input Type: <any> ----
  | initialise a `Point`
  | 
  | Usage:


### PR DESCRIPTION
Prototype separating intrinsics based on input type (#120).

Alters the `Implementations` structure and how help messages are presented, closing #124