### PR TITLE
Add more robustness checks for variables that do not exist

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 - Detect trailing command in `let` and suggest a pipe (https://github.com/kdr-aus/ogma/pull/113)
 - Fix error where stronger type guarantees were present (https://github.com/kdr-aus/ogma/pull/117)
 - Fix def not inferring correct input in `last` (https://github.com/kdr-aus/ogma/pull/147)
+- Fix _locals graph needs updating_ bug (https://github.com/kdr-aus/ogma/pull/148)
 
 **✨ Other Updates**
 - `ogma` crate API documentation is now published at https://kdr-aus.github.io/ogma/ogma/ (https://github.com/kdr-aus/ogma/commit/cf5cc7979c399b609e2e0605ffe176e70e474ac2)

--- a/ogma/src/eng/arg.rs
+++ b/ogma/src/eng/arg.rs
@@ -203,6 +203,7 @@ impl<'a> ArgBuilder<'a> {
             Flag(_) => unreachable!("an argument cannot be a Flag variant"),
             Intrinsic { .. } => unreachable!("an argument cannot be a Intrinsic variant"),
             Def { .. } => unreachable!("an argument cannot be a Def variant"),
+
             Ident(s) => Ok(Hold::Lit(Str::new(s.str()).into())),
             Num { val, tag: _ } => Ok(Hold::Lit((*val).into())),
             Pound {
@@ -220,7 +221,7 @@ impl<'a> ArgBuilder<'a> {
             Pound {
                 ty: Pt::Newline,
                 tag: _,
-            } => Ok(Hold::Lit(Value::Str(Str::from("\n")))),
+            } => Ok(Hold::Lit(Value::Str(Str::from('\n')))),
             Pound {
                 ty: Pt::Input,
                 tag: _,
@@ -242,14 +243,17 @@ impl<'a> ArgBuilder<'a> {
 
                 Ok(Hold::Expr(stack))
             }
-            Var(tag) => lg
-                .get_checked(node.idx(), tag.str(), tag)
+            Var(tag) => {
+                dbg!(node, tag);
+                dbg!(lg
+                .get_checked(node.idx(), tag.str(), tag))
                 .and_then(|local| match local {
                     Local::Var(var) => Ok(Hold::Var(var.clone())),
                     Local::Ptr { .. } => {
                         unreachable!("a param argument should shadow the referencer arg node")
                     }
-                }),
+                })
+            }
             Expr(tag) => compiled_exprs
                 .get(&node.index())
                 .cloned()

--- a/ogma/src/eng/arg.rs
+++ b/ogma/src/eng/arg.rs
@@ -243,17 +243,14 @@ impl<'a> ArgBuilder<'a> {
 
                 Ok(Hold::Expr(stack))
             }
-            Var(tag) => {
-                dbg!(node, tag);
-                dbg!(lg
-                .get_checked(node.idx(), tag.str(), tag))
+            Var(tag) => lg
+                .get_checked(node.idx(), tag.str(), tag)
                 .and_then(|local| match local {
                     Local::Var(var) => Ok(Hold::Var(var.clone())),
                     Local::Ptr { .. } => {
                         unreachable!("a param argument should shadow the referencer arg node")
                     }
-                })
-            }
+                }),
             Expr(tag) => compiled_exprs
                 .get(&node.index())
                 .cloned()

--- a/ogma/src/eng/comp/infer.rs
+++ b/ogma/src/eng/comp/infer.rs
@@ -32,7 +32,7 @@ impl<'d> Compiler<'d> {
             // 3. has multiple valid types
             self.tg[n].input.is_multiple() &&
             // 4. is sealed, or contains no variables
-            (self.lg.sealed(n) || !self.ag.detect_var(OpNode(n)))
+            ((self.lg.sealed(n) && false) || !self.ag.detect_var(OpNode(n)))
         });
 
         let mut chgs = Vec::new();

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -130,7 +130,7 @@ impl<'d> Compiler<'d> {
             self.resolve_tg()?;
 
             // NOTE turn on for debugging.
-            self._write_debug_report("debug-compiler.md");
+            // self._write_debug_report("debug-compiler.md");
 
             if self.populate_compiled_expressions() {
                 continue;

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -130,7 +130,7 @@ impl<'d> Compiler<'d> {
             self.resolve_tg()?;
 
             // NOTE turn on for debugging.
-            // self._write_debug_report("debug-compiler.md");
+            self._write_debug_report("debug-compiler.md");
 
             if self.populate_compiled_expressions() {
                 continue;

--- a/ogma/src/eng/graphs/locals_graph.rs
+++ b/ogma/src/eng/graphs/locals_graph.rs
@@ -321,8 +321,34 @@ impl LocalsGraph {
     /// An op's successful compilation would seal it.
     pub fn seal_node(&mut self, node: NodeIndex, ag: &AstGraph) {
         self.graph[node].sealed = true; // seal itself
+
+        let mut stack = self.graph.neighbors(node).collect::<Vec<_>>();
+
+        while let Some(n) = stack.pop() {
+            self.graph[n].sealed = true; // seal flow targets
+
+            // if flow target is an expression, seal the expr's first op as well
+            if let Some(e) = ag[n].expr().map(|_| ExprNode(n)) {
+                stack.push(e.first_op(ag).idx());
+            }
+
+            // if the flow target is an Op (ie next block), seal the **argument** nodes
+            // NOTE: this is done since an Op should not have variable definition power that would
+            // influence the op's arguments...
+            if ag[n].op().is_some() {
+                stack.extend(self.graph.neighbors(n)
+                        // do not filter the next op though
+                    .filter(|&n| ag[n].op().is_none()));
+            }
+        }
+
+        return;
+
+        dbg!(node);
         let mut wlkr = self.graph.neighbors(node).detach();
         while let Some(n) = wlkr.next_node(&self.graph) {
+            dbg!(n);
+
             self.graph[n].sealed = true; // seal flow targets
 
             // if flow target is an expression, seal the expr's first op as well
@@ -337,8 +363,10 @@ impl LocalsGraph {
                 let mut wlkr = self.graph.neighbors(n).detach();
                 while let Some(n) = wlkr
                     .next_node(&self.graph)
+                        // do not filter the next op though
                     .filter(|&n| ag[n].op().is_none())
                 {
+                    dbg!(n);
                     self.graph[n].sealed = true;
                 }
             }

--- a/ogma/src/eng/graphs/locals_graph.rs
+++ b/ogma/src/eng/graphs/locals_graph.rs
@@ -320,7 +320,11 @@ impl LocalsGraph {
     /// Seal an op or expr node, flagging that there will not be any more variables introduced.
     /// An op's successful compilation would seal it.
     pub fn seal_node(&mut self, node: NodeIndex, ag: &AstGraph) {
-        self.graph[node].sealed = true; // seal itself
+        if ag[node].expr().is_some() {
+            // if sealing an expression seal itself
+            // NOTE we do NOT seal op's as themselves
+            self.graph[node].sealed = true;
+        }
 
         let mut stack = self.graph.neighbors(node).collect::<Vec<_>>();
 
@@ -342,9 +346,12 @@ impl LocalsGraph {
             // NOTE: this is done since an Op should not have variable definition power that would
             // influence the op's arguments...
             if ag[n].op().is_some() {
-                stack.extend(self.graph.neighbors(n)
+                stack.extend(
+                    self.graph
+                        .neighbors(n)
                         // do not filter the next op though
-                    .filter(|&n| ag[n].op().is_none()));
+                        .filter(|&n| ag[n].op().is_none()),
+                );
             }
         }
     }

--- a/ogma/src/eng/graphs/mod.rs
+++ b/ogma/src/eng/graphs/mod.rs
@@ -69,10 +69,7 @@ impl From<locals_graph::Chg> for Chg {
 
 impl Chg {
     pub fn is_lg_chg(&self) -> bool {
-        match self {
-            Chg::Lg(_) => true,
-            _ => false,
-        }
+        matches!(self, Chg::Lg(_))
     }
 }
 

--- a/ogma/tests/commands/definitions.rs
+++ b/ogma/tests/commands/definitions.rs
@@ -437,7 +437,9 @@ fn variable_not_defined_in_def() {
 
     let x = process_w_table("foo", defs).unwrap_err().to_string();
     println!("{x}");
-    assert_eq!(&x, "Semantics Error: variable `col` does not exist
+    assert_eq!(
+        &x,
+        "Semantics Error: variable `col` does not exist
 --> shell:33
  | def foo Table () { append { get $col } }
  |                                  ^^^ `col` not in scope
@@ -446,7 +448,8 @@ fn variable_not_defined_in_def() {
  | ^^^ invoked here
 --> help: variables must be in scope
           variables can be defined using the `let` command
-");
+"
+    );
 
     // from bug 137
     process_definition(
@@ -472,7 +475,9 @@ fn variable_not_defined_in_def() {
     .unwrap_err()
     .to_string();
     println!("{x}");
-    assert_eq!(&x, r#"Semantics Error: variable `col` does not exist
+    assert_eq!(
+        &x,
+        r#"Semantics Error: variable `col` does not exist
 --> shell:37
  |     | let { fold 0 + { \ $row | get $col} | / $len } $mean
  |                                      ^^^ `col` not in scope
@@ -481,5 +486,6 @@ fn variable_not_defined_in_def() {
  |             ^^^^^^^^^^^^^^^^^^^ invoked here
 --> help: variables must be in scope
           variables can be defined using the `let` command
-"#);
+"#
+    );
 }

--- a/ogma/tests/commands/definitions.rs
+++ b/ogma/tests/commands/definitions.rs
@@ -437,7 +437,16 @@ fn variable_not_defined_in_def() {
 
     let x = process_w_table("foo", defs).unwrap_err().to_string();
     println!("{x}");
-    assert_eq!(&x, "");
+    assert_eq!(&x, "Semantics Error: variable `col` does not exist
+--> shell:33
+ | def foo Table () { append { get $col } }
+ |                                  ^^^ `col` not in scope
+--> shell:0
+ | foo
+ | ^^^ invoked here
+--> help: variables must be in scope
+          variables can be defined using the `let` command
+");
 
     // from bug 137
     process_definition(
@@ -463,5 +472,14 @@ fn variable_not_defined_in_def() {
     .unwrap_err()
     .to_string();
     println!("{x}");
-    assert_eq!(&x, "");
+    assert_eq!(&x, r#"Semantics Error: variable `col` does not exist
+--> shell:37
+ |     | let { fold 0 + { \ $row | get $col} | / $len } $mean
+ |                                      ^^^ `col` not in scope
+--> shell:12
+ | | map value sim-characteristics
+ |             ^^^^^^^^^^^^^^^^^^^ invoked here
+--> help: variables must be in scope
+          variables can be defined using the `let` command
+"#);
 }

--- a/ogma/tests/commands/mod.rs
+++ b/ogma/tests/commands/mod.rs
@@ -477,7 +477,9 @@ fn variables_not_existing() {
 "#
     );
 
-    let x = process_w_table("let $a | \\ $t", defs).unwrap_err().to_string();
+    let x = process_w_table("let $a | \\ $t", defs)
+        .unwrap_err()
+        .to_string();
     println!("{x}");
     assert_eq!(
         &x,
@@ -490,7 +492,12 @@ fn variables_not_existing() {
 "#
     );
 
-    let x = process_w_table("append { get $col }", defs).unwrap_err().to_string();
+    let x = process_w_nil("let $a | \\ $a", defs);
+    assert_eq!(x, Ok(Value::Nil));
+
+    let x = process_w_table("append { get $col }", defs)
+        .unwrap_err()
+        .to_string();
     println!("{x}");
     assert_eq!(
         &x,
@@ -503,7 +510,9 @@ fn variables_not_existing() {
 "
     );
 
-    let x = process_w_table("append { let $a | get $col }", defs).unwrap_err().to_string();
+    let x = process_w_table("append { let $a | get $col }", defs)
+        .unwrap_err()
+        .to_string();
     println!("{x}");
     assert_eq!(
         &x,
@@ -514,6 +523,24 @@ fn variables_not_existing() {
 --> help: variables must be in scope
           variables can be defined using the `let` command
 "
+    );
+
+    let x = process_w_table("append { let 'first' $a | get:Num $a } | \\ 3", defs);
+    assert_eq!(x, Ok(Value::Num(3.into())));
+
+    let x = process_w_table("let { nth 0 get $col } $c | \\ $c", defs)
+        .unwrap_err()
+        .to_string();
+    println!("{x}");
+    assert_eq!(
+        &x,
+        r#"Semantics Error: variable `col` does not exist
+--> shell:17
+ | let { nth 0 get $col } $c | \ $c
+ |                  ^^^ `col` not in scope
+--> help: variables must be in scope
+          variables can be defined using the `let` command
+"#
     );
 }
 

--- a/ogma/tests/commands/mod.rs
+++ b/ogma/tests/commands/mod.rs
@@ -460,6 +460,63 @@ fn no_cmd_defined() {
     );
 }
 
+#[test]
+fn variables_not_existing() {
+    let defs = &Definitions::new();
+
+    let x = process_w_table("\\ $t", defs).unwrap_err().to_string();
+    println!("{x}");
+    assert_eq!(
+        &x,
+        r#"Semantics Error: variable `t` does not exist
+--> shell:3
+ | \ $t
+ |    ^ `t` not in scope
+--> help: variables must be in scope
+          variables can be defined using the `let` command
+"#
+    );
+
+    let x = process_w_table("let $a | \\ $t", defs).unwrap_err().to_string();
+    println!("{x}");
+    assert_eq!(
+        &x,
+        r#"Semantics Error: variable `t` does not exist
+--> shell:12
+ | let $a | \ $t
+ |             ^ `t` not in scope
+--> help: variables must be in scope
+          variables can be defined using the `let` command
+"#
+    );
+
+    let x = process_w_table("append { get $col }", defs).unwrap_err().to_string();
+    println!("{x}");
+    assert_eq!(
+        &x,
+        "Semantics Error: variable `col` does not exist
+--> shell:14
+ | append { get $col }
+ |               ^^^ `col` not in scope
+--> help: variables must be in scope
+          variables can be defined using the `let` command
+"
+    );
+
+    let x = process_w_table("append { let $a | get $col }", defs).unwrap_err().to_string();
+    println!("{x}");
+    assert_eq!(
+        &x,
+        "Semantics Error: variable `col` does not exist
+--> shell:23
+ | append { let $a | get $col }
+ |                        ^^^ `col` not in scope
+--> help: variables must be in scope
+          variables can be defined using the `let` command
+"
+    );
+}
+
 // ------ General Bugs ---------------------------------------------------------
 #[test]
 fn gt_should_resolve_as_bool_return_type() {

--- a/ogma/tests/commands/mod.rs
+++ b/ogma/tests/commands/mod.rs
@@ -544,6 +544,26 @@ fn variables_not_existing() {
     );
 }
 
+#[test]
+fn variables_not_existing_with_fold_call() {
+    let defs = &Definitions::new();
+
+    let x = process_w_table("fold {Table} { get $col }", defs)
+        .unwrap_err()
+        .to_string();
+    println!("{x}");
+    assert_eq!(
+        &x,
+        r#"Semantics Error: variable `col` does not exist
+--> shell:20
+ | fold {Table} { get $col }
+ |                     ^^^ `col` not in scope
+--> help: variables must be in scope
+          variables can be defined using the `let` command
+"#
+    );
+}
+
 // ------ General Bugs ---------------------------------------------------------
 #[test]
 fn gt_should_resolve_as_bool_return_type() {

--- a/ogma/tests/commands/pipeline.rs
+++ b/ogma/tests/commands/pipeline.rs
@@ -482,7 +482,6 @@ fn last_testing_bug_116() {
         r#"ls | grp name | fold 0 { \$row | get value | last get:Num size }"#,
         defs,
     );
-    dbg!(&x);
     assert!(matches!(x, Ok(Value::Num(_))));
 }
 


### PR DESCRIPTION
Fixes #137 

This was due to a cycle in the locals graph needing updating.
This PR fixes this by altering the way LG nodes are sealed.
It also addresses some robustness bugs with the inferencer that this change introduced.