### PR TITLE
Variable sealing rework

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,8 @@
 - Fix _locals graph needs updating_ bug (https://github.com/kdr-aus/ogma/pull/148)
 - Provide more verbose parsing errors (https://github.com/kdr-aus/ogma/pull/151)
 - Fix CPU spinning with completion prompt open (https://github.com/kdr-aus/ogma/pull/152)
+- Fix an uncommon variable shadowing bug by reworking the variable sealing system
+    (https://github.com/kdr-aus/ogma/pull/154)
 
 **✨ Other Updates**
 - `ogma` crate API documentation is now published at https://kdr-aus.github.io/ogma/ogma/ (https://github.com/kdr-aus/ogma/commit/cf5cc7979c399b609e2e0605ffe176e70e474ac2)

--- a/ogma/src/eng/arg.rs
+++ b/ogma/src/eng/arg.rs
@@ -40,9 +40,19 @@ impl<'a> ArgBuilder<'a> {
     }
 
     fn follow_local_arg_ptr(mut self: Box<Self>) -> Box<Self> {
+
+        dbg!("follow_local_arg_ptr");
         let new_node = self.compiler.ag[self.node.idx()]
             .var()
             .and_then(|t| self.compiler.lg.get(self.node.idx(), t.str()))
+            .map(|l| {
+
+//         if self.node.index() == 25 {
+//             self.compiler._write_debug_report("debug-compiler.md");
+//             panic!()
+//         }
+        l
+            })
             .and_then(|l| match l {
                 Local::Ptr { to, tag: _ } => Some(to),
                 _ => None,
@@ -273,6 +283,7 @@ impl<'a> ArgBuilder<'a> {
     pub fn assert_var_exists(&self) -> Result<Option<bool>> {
         let Compiler { ag, lg, .. } = self.compiler;
 
+        dbg!("assert_var_exists");
         match &ag[self.node.idx()] {
             astgraph::AstNode::Var(tag) => {
                 lg.get(self.node.idx(), tag.str())

--- a/ogma/src/eng/arg.rs
+++ b/ogma/src/eng/arg.rs
@@ -13,14 +13,14 @@ pub struct ArgBuilder<'a> {
 
     compiler: &'a Compiler<'a>,
     blk_in_ty: Option<Type>,
-    chgs: Chgs<'a>,
+    chgs: &'a mut Chgs,
 }
 
 impl<'a> ArgBuilder<'a> {
     pub(super) fn new(
         node: ArgNode,
         compiler: &'a Compiler<'a>,
-        chgs: Chgs<'a>,
+        chgs: &'a mut Chgs,
         blk_in_ty: Option<Type>,
     ) -> Box<Self> {
         // see if the input and/or output types are known
@@ -40,19 +40,9 @@ impl<'a> ArgBuilder<'a> {
     }
 
     fn follow_local_arg_ptr(mut self: Box<Self>) -> Box<Self> {
-
-        dbg!("follow_local_arg_ptr");
         let new_node = self.compiler.ag[self.node.idx()]
             .var()
-            .and_then(|t| self.compiler.lg.get(self.node.idx(), t.str()))
-            .map(|l| {
-
-//         if self.node.index() == 25 {
-//             self.compiler._write_debug_report("debug-compiler.md");
-//             panic!()
-//         }
-        l
-            })
+            .and_then(|t| self.compiler.get_local_opt(self.node.idx(), t.str()).1)
             .and_then(|l| match l {
                 Local::Ptr { to, tag: _ } => Some(to),
                 _ => None,
@@ -109,6 +99,7 @@ impl<'a> ArgBuilder<'a> {
                     "expecting TypesSet to not be empty or a single set"
                 );
                 self.chgs
+                    .chgs
                     .push(tygraph::Chg::KnownInput(self.node.idx(), ty).into());
                 Err(Error::unknown_arg_input_type(self.tag()))
             }
@@ -142,6 +133,7 @@ impl<'a> ArgBuilder<'a> {
                     "expecting TypesSet to not be empty or a single set"
                 );
                 self.chgs
+                    .chgs
                     .push(tygraph::Chg::ObligeOutput(self.node.idx(), ty).into());
                 Err(Error::unknown_arg_output_type(self.tag()))
             }
@@ -253,14 +245,16 @@ impl<'a> ArgBuilder<'a> {
 
                 Ok(Hold::Expr(stack))
             }
-            Var(tag) => lg
-                .get_checked(node.idx(), tag.str(), tag)
-                .and_then(|local| match local {
-                    Local::Var(var) => Ok(Hold::Var(var.clone())),
-                    Local::Ptr { .. } => {
-                        unreachable!("a param argument should shadow the referencer arg node")
-                    }
-                }),
+            Var(tag) => {
+                compiler
+                    .get_local(node.idx(), tag.str(), tag)
+                    .and_then(|local| match local {
+                        Local::Var(var) => Ok(Hold::Var(var.clone())),
+                        Local::Ptr { .. } => {
+                            unreachable!("a param argument should shadow the referencer arg node")
+                        }
+                    })
+            }
             Expr(tag) => compiled_exprs
                 .get(&node.index())
                 .cloned()
@@ -281,25 +275,13 @@ impl<'a> ArgBuilder<'a> {
     /// - `Ok(Some(true))`: The variable exists in the locals,
     /// - `Err(_)`: The variable does not exist in the locals.
     pub fn assert_var_exists(&self) -> Result<Option<bool>> {
-        let Compiler { ag, lg, .. } = self.compiler;
-
-        dbg!("assert_var_exists");
-        match &ag[self.node.idx()] {
-            astgraph::AstNode::Var(tag) => {
-                lg.get(self.node.idx(), tag.str())
-                    // Ok(Some(true)) if variable exists
-                    .map(|_| true)
-                    // if NOT sealed, return Ok(Some(false)) -- lg should be updated
-                    // NOTE we check the parent op for seal, not the argument itself.
-                    .or_else(|| {
-                        let sealed = lg.sealed(self.node.op(ag).idx());
-                        (!sealed).then(|| false)
-                    })
-                    // Error with a HARD error
-                    .ok_or_else(|| Error::var_not_found(tag))
-                    .map(Some)
-            }
-            _ => Ok(None), // not a variable
+        match self.node.var(self.compiler.ag()) {
+            Some(var) => match self.compiler.get_local_opt(self.node.idx(), var.str()) {
+                (true, Some(_)) => Ok(Some(true)),
+                (true, None) => Err(Error::var_not_found(var)),
+                (false, _) => Ok(Some(false)),
+            },
+            None => Ok(None), // not a variable
         }
     }
 }

--- a/ogma/src/eng/blk.rs
+++ b/ogma/src/eng/blk.rs
@@ -66,6 +66,7 @@ impl<'a> Block<'a> {
         }
 
         self.chgs
+            .chgs
             .push(graphs::tygraph::Chg::KnownOutput(self.node.idx(), ty).into());
     }
 
@@ -73,7 +74,7 @@ impl<'a> Block<'a> {
     ///
     /// Note that this will not affect already resolved nodes, only inferred nodes.
     pub fn insert_anon_type_into_compiler(&mut self, ty: Type) {
-        self.chgs.push(graphs::tygraph::Chg::AnonTy(ty).into());
+        self.chgs.chgs.push(graphs::tygraph::Chg::AnonTy(ty).into());
     }
 
     /// Gets the flag that matches a given name.
@@ -124,7 +125,7 @@ impl<'a> Block<'a> {
                 Some(next) => lg
                     .new_var(next.idx(), Str::new(var.str()), ty, var.clone())
                     .map_err(|chg| {
-                        chgs.push(chg.into());
+                        chgs.chgs.push(chg.into());
                         Error::update_locals_graph(var)
                     }),
                 None => Ok(Variable::noop(var.clone(), ty)),
@@ -168,7 +169,7 @@ impl<'a> Block<'a> {
             .lg
             .new_var(arg.idx(), name, ty, tag.clone())
             .map_err(|chg| {
-                self.chgs.push(chg.into());
+                self.chgs.chgs.push(chg.into());
                 Error::update_locals_graph(tag)
             })
     }

--- a/ogma/src/eng/comp/infer.rs
+++ b/ogma/src/eng/comp/infer.rs
@@ -32,7 +32,7 @@ impl<'d> Compiler<'d> {
             // 3. has multiple valid types
             self.tg[n].input.is_multiple() &&
             // 4. is sealed, or contains no variables
-            (self.sealed(n) || !self.ag.detect_var(OpNode(n)))
+            (self.lg.sealed(n) || !self.ag.detect_var(OpNode(n)))
         });
 
         let mut chgs = Vec::default();

--- a/ogma/src/eng/comp/infer.rs
+++ b/ogma/src/eng/comp/infer.rs
@@ -32,10 +32,10 @@ impl<'d> Compiler<'d> {
             // 3. has multiple valid types
             self.tg[n].input.is_multiple() &&
             // 4. is sealed, or contains no variables
-            (self.lg.sealed(n) || !self.ag.detect_var(OpNode(n)))
+            (self.sealed(n) || !self.ag.detect_var(OpNode(n)))
         });
 
-        let mut chgs = Vec::new();
+        let mut chgs = Vec::default();
 
         for op in infer_nodes.into_iter().map(OpNode) {
             trial_inferred_types(op, self, &mut chgs);
@@ -143,8 +143,8 @@ enum Error {
 
 /// Tries to compile the `op` with each type in the inferred types set.
 /// Pushes `RemoveInput` if failed.
-fn trial_inferred_types(op: OpNode, compiler: &Compiler, chgs: Chgs) {
-    let sink1 = &mut Default::default();
+fn trial_inferred_types(op: OpNode, compiler: &Compiler, chgs: &mut Vec<graphs::Chg>) {
+    let mut sink1 = Default::default();
 
     let set = compiler.tg[op.idx()]
         .input
@@ -155,10 +155,17 @@ fn trial_inferred_types(op: OpNode, compiler: &Compiler, chgs: Chgs) {
         .iter()
         .cloned()
         .filter(|ty| {
-            let infer_output = &mut false;
+            let mut chgs = Chgs {
+                chgs: std::mem::take(&mut sink1),
+                ..Chgs::default()
+            };
+
             let compiled = compiler
-                .compile_block(op, ty.clone(), sink1, infer_output)
+                .compile_block(op, ty.clone(), &mut chgs)
                 .is_ok();
+
+            let Chgs { chgs, infer_output, adds_vars } = chgs;
+            sink1 = chgs;
 
             let lg_chg_req = sink1.drain(..).any(|chg| chg.is_lg_chg());
 
@@ -167,7 +174,7 @@ fn trial_inferred_types(op: OpNode, compiler: &Compiler, chgs: Chgs) {
             // we keep in if infer_output is true, since we need more information about types
             // before we can compile this block, and removing input inferences will just reduce it
             // to an empty set.
-            !compiled && !*infer_output && !lg_chg_req
+            !compiled && !infer_output && !lg_chg_req
         })
         .map(|ty| RemoveInput(op.into(), ty))
         .map(Into::into);
@@ -316,7 +323,7 @@ impl<'a> Block<'a> {
         let Block {
             node: opnode,
             compiler: Compiler { ag, tg, .. },
-            infer_output,
+            chgs: Chgs { infer_output, .. },
             ..
         } = self;
 
@@ -340,7 +347,7 @@ impl<'a> Block<'a> {
             .cloned();
 
         if ret.is_none() {
-            **infer_output = true;
+            *infer_output = true;
         }
 
         ret

--- a/ogma/src/eng/comp/infer.rs
+++ b/ogma/src/eng/comp/infer.rs
@@ -160,11 +160,13 @@ fn trial_inferred_types(op: OpNode, compiler: &Compiler, chgs: &mut Vec<graphs::
                 ..Chgs::default()
             };
 
-            let compiled = compiler
-                .compile_block(op, ty.clone(), &mut chgs)
-                .is_ok();
+            let compiled = compiler.compile_block(op, ty.clone(), &mut chgs).is_ok();
 
-            let Chgs { chgs, infer_output, adds_vars } = chgs;
+            let Chgs {
+                chgs,
+                infer_output,
+                adds_vars: _,
+            } = chgs;
             sink1 = chgs;
 
             let lg_chg_req = sink1.drain(..).any(|chg| chg.is_lg_chg());

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -130,7 +130,7 @@ impl<'d> Compiler<'d> {
             self.resolve_tg()?;
 
             // NOTE turn on for debugging.
-            // self._write_debug_report("debug-compiler.md");
+            self._write_debug_report("debug-compiler.md");
 
             if self.populate_compiled_expressions() {
                 continue;
@@ -270,10 +270,12 @@ impl<'d> Compiler<'d> {
             }
 
             // map in if has a Locals
+            dbg!("assign_variable_types");
             let local = match self.lg.get(node, var_tag.str()) {
                 Some(l) => l,
                 None => continue,
             };
+            dbg!(local);
 
             match local {
                 Local::Var(v) => {

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -270,8 +270,7 @@ impl<'d> Compiler<'d> {
             }
 
             // map in if has a Locals
-            dbg!("assign_variable_types");
-            let local = match self.lg.get(node, var_tag.str()) {
+            let local = match self.get_local_opt(node, var_tag.str()).1 {
                 Some(l) => l,
                 None => continue,
             };
@@ -358,7 +357,11 @@ impl<'d> Compiler<'d> {
 
         let mut goto_resolve = false;
         let mut err = None;
-        let mut chgs = Vec::new();
+        let mut chgs = Chgs {
+            chgs: Vec::new(),
+            infer_output: false,
+            adds_vars: false
+        };
 
         for node in nodes {
             let in_ty = self.tg[node.idx()]
@@ -367,9 +370,10 @@ impl<'d> Compiler<'d> {
                 .cloned()
                 .expect("known input at this point");
 
-            let mut infer_output = false;
+            chgs.infer_output = false;
+            chgs.adds_vars = false;
 
-            match self.compile_block(node, in_ty, &mut chgs, &mut infer_output) {
+            match self.compile_block(node, in_ty, &mut chgs) {
                 Ok(step) => {
                     goto_resolve = true;
                     let out_ty = step.out_ty.clone();
@@ -383,15 +387,11 @@ impl<'d> Compiler<'d> {
 
                     // since this compilation was successful, the output type is known!
                     // the TG is updated with this information
-                    chgs.push(tygraph::Chg::KnownOutput(node.idx(), out_ty).into());
-
-                    // we also seal off the op node in the locals graph, this op is not going to
-                    // alter it's dependent locals maps
-                    self.lg.seal_node(node.idx(), &self.ag);
+                    chgs.chgs.push(tygraph::Chg::KnownOutput(node.idx(), out_ty).into());
                 }
                 Err(mut e) => {
                     // only set the infer output if tygraph is showing that it has multiple options
-                    if infer_output {
+                    if chgs.infer_output {
                         let _unknown = self.tg[node.idx()].output.is_multiple();
                         debug_assert!(
                             _unknown,
@@ -420,9 +420,11 @@ impl<'d> Compiler<'d> {
                     err = Some(e);
                 }
             }
+
+            chgs.chgs.push(locals_graph::Chg::AddsVar(node, chgs.adds_vars).into());
         }
 
-        let chgd = self.apply_graph_chgs(chgs.into_iter())?;
+        let chgd = self.apply_graph_chgs(chgs.chgs.into_iter())?;
 
         (goto_resolve | chgd)
             .then(|| ())
@@ -434,8 +436,7 @@ impl<'d> Compiler<'d> {
         &self,
         opnode: OpNode,
         in_ty: Type,
-        chgs: Chgs,
-        infer_output: &mut bool,
+        chgs: &mut Chgs,
     ) -> Result<Step> {
         let cmd_node = self.ag.get_impl(opnode, &in_ty).ok_or_else(|| {
             Error::op_not_found(
@@ -448,7 +449,7 @@ impl<'d> Compiler<'d> {
 
         match &self.ag[cmd_node.idx()] {
             AstNode::Intrinsic { op: _op, intrinsic } => {
-                let block = Block::construct(self, cmd_node, in_ty, chgs, infer_output);
+                let block = Block::construct(self, cmd_node, in_ty, chgs);
                 intrinsic(block)
             }
             AstNode::Def { expr: _, params: _ } => {
@@ -475,7 +476,7 @@ impl<'d> Compiler<'d> {
                     None => {
                         // there is not, but we can add to the TG that this sub-expression will
                         // have input of `in_ty`.
-                        chgs.push(tygraph::Chg::KnownInput(expr.idx(), in_ty).into());
+                        chgs.chgs.push(tygraph::Chg::KnownInput(expr.idx(), in_ty).into());
 
                         Err(Error::incomplete_expr_compilation(
                             self.ag[expr.idx()].tag(),
@@ -511,7 +512,7 @@ impl<'d> Compiler<'d> {
         &self,
         def: DefNode,
         in_ty: &Type,
-        chgs: Chgs,
+        chgs: &mut Chgs,
     ) -> Result<Vec<(Variable, Argument)>> {
         let Compiler {
             ag,
@@ -607,8 +608,7 @@ impl<'a> Block<'a> {
         compiler: &'a Compiler,
         node: CmdNode,
         in_ty: Type,
-        chgs: Chgs<'a>,
-        output_infer: &'a mut bool,
+        chgs: &'a mut Chgs,
     ) -> Self {
         let opnode = node.parent(&compiler.ag);
         let mut flags = compiler.ag.get_flags(node);
@@ -625,7 +625,6 @@ impl<'a> Block<'a> {
             args,
             args_count: 0,
             chgs,
-            infer_output: output_infer,
             #[cfg(debug_assertions)]
             output_ty: None,
         }
@@ -746,6 +745,9 @@ mod tests {
     fn compilation_test_07() {
         // initial variable testing
         compile("let $x | \\ $x").unwrap();
+
+        eprintln!("TEST #2 ------- \\ 3 | let $a | = $a");
+        compile("\\ 3 | let $a | = $a").unwrap();
     }
 
     #[test]

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -130,7 +130,7 @@ impl<'d> Compiler<'d> {
             self.resolve_tg()?;
 
             // NOTE turn on for debugging.
-            self._write_debug_report("debug-compiler.md");
+            // self._write_debug_report("debug-compiler.md");
 
             if self.populate_compiled_expressions() {
                 continue;
@@ -274,7 +274,6 @@ impl<'d> Compiler<'d> {
                 Some(l) => l,
                 None => continue,
             };
-            dbg!(local);
 
             match local {
                 Local::Var(v) => {
@@ -360,7 +359,7 @@ impl<'d> Compiler<'d> {
         let mut chgs = Chgs {
             chgs: Vec::new(),
             infer_output: false,
-            adds_vars: false
+            adds_vars: false,
         };
 
         for node in nodes {
@@ -387,7 +386,8 @@ impl<'d> Compiler<'d> {
 
                     // since this compilation was successful, the output type is known!
                     // the TG is updated with this information
-                    chgs.chgs.push(tygraph::Chg::KnownOutput(node.idx(), out_ty).into());
+                    chgs.chgs
+                        .push(tygraph::Chg::KnownOutput(node.idx(), out_ty).into());
                 }
                 Err(mut e) => {
                     // only set the infer output if tygraph is showing that it has multiple options
@@ -434,12 +434,7 @@ impl<'d> Compiler<'d> {
     }
 
     /// Try to compile `opnode` into an evaluation [`Step`] given the input type (`in_ty`).
-    pub fn compile_block(
-        &self,
-        opnode: OpNode,
-        in_ty: Type,
-        chgs: &mut Chgs,
-    ) -> Result<Step> {
+    pub fn compile_block(&self, opnode: OpNode, in_ty: Type, chgs: &mut Chgs) -> Result<Step> {
         let cmd_node = self.ag.get_impl(opnode, &in_ty).ok_or_else(|| {
             Error::op_not_found(
                 self.ag[opnode.idx()].tag(),
@@ -478,7 +473,8 @@ impl<'d> Compiler<'d> {
                     None => {
                         // there is not, but we can add to the TG that this sub-expression will
                         // have input of `in_ty`.
-                        chgs.chgs.push(tygraph::Chg::KnownInput(expr.idx(), in_ty).into());
+                        chgs.chgs
+                            .push(tygraph::Chg::KnownInput(expr.idx(), in_ty).into());
 
                         Err(Error::incomplete_expr_compilation(
                             self.ag[expr.idx()].tag(),
@@ -606,12 +602,7 @@ impl<'a> Compiler<'a> {
 }
 
 impl<'a> Block<'a> {
-    fn construct(
-        compiler: &'a Compiler,
-        node: CmdNode,
-        in_ty: Type,
-        chgs: &'a mut Chgs,
-    ) -> Self {
+    fn construct(compiler: &'a Compiler, node: CmdNode, in_ty: Type, chgs: &'a mut Chgs) -> Self {
         let opnode = node.parent(&compiler.ag);
         let mut flags = compiler.ag.get_flags(node);
         let mut args = compiler.ag.get_args(node);

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -270,7 +270,7 @@ impl<'d> Compiler<'d> {
             }
 
             // map in if has a Locals
-            let local = match self.get_local_opt(node, var_tag.str()).1 {
+            let local = match self.lg.get_opt(node, var_tag.str()).1 {
                 Some(l) => l,
                 None => continue,
             };
@@ -421,7 +421,9 @@ impl<'d> Compiler<'d> {
                 }
             }
 
-            chgs.chgs.push(locals_graph::Chg::AddsVar(node, chgs.adds_vars).into());
+            if !chgs.adds_vars {
+                chgs.chgs.push(locals_graph::Chg::Seal(node).into());
+            }
         }
 
         let chgd = self.apply_graph_chgs(chgs.chgs.into_iter())?;

--- a/ogma/src/eng/graphs/locals_graph.rs
+++ b/ogma/src/eng/graphs/locals_graph.rs
@@ -47,10 +47,7 @@ pub enum Chg {
     /// Removes a connection between the op and arg.
     /// This is useful for ops such as `let` which might need it's arguments to be able to compile
     /// without `let` op needing to be 'sealed'.
-    BreakEdge {
-        op: OpNode,
-        arg: ArgNode
-    }
+    BreakEdge { op: OpNode, arg: ArgNode },
 }
 
 /// A graph structure which tracks variables, allowing for lexical scoping and shadowing.
@@ -190,8 +187,7 @@ impl LocalsGraph {
     pub fn get(&self, node: NodeIndex, name: &str, tag: &Tag) -> Result<&eng::Local> {
         self.sealed(node)
             .then(|| {
-                self
-                    .get_(node, name)
+                self.get_(node, name)
                     .ok_or_else(|| Error::var_not_found(tag))
             })
             .ok_or_else(|| Error::update_locals_graph(tag))
@@ -323,23 +319,21 @@ impl LocalsGraph {
     }
 
     fn neighbours_flow(&self, n: NodeIndex) -> impl Iterator<Item = NodeIndex> + '_ {
-        self
-            .graph
+        self.graph
             .edges(n)
             .filter_map(|e| e.weight().is_flow().then(|| e.target()))
     }
 
     fn neighbours_seal(&self, n: NodeIndex) -> impl Iterator<Item = NodeIndex> + '_ {
-        self
-            .graph
+        self.graph
             .edges(n)
             .filter_map(|e| e.weight().is_seal().then(|| e.target()))
     }
 
-
-
     fn flow(&mut self, from: NodeIndex) {
-        let mut stack = self.neighbours_flow(from).map(|to| (from, to))
+        let mut stack = self
+            .neighbours_flow(from)
+            .map(|to| (from, to))
             .collect::<Vec<_>>();
 
         while let Some((from, to)) = stack.pop() {
@@ -393,8 +387,7 @@ impl LocalsGraph {
     }
 
     /// Checks that this node is sealed and no variables will be introduced along the path to root.
-    pub fn sealed(&self, node: NodeIndex) -> bool
-    {
+    pub fn sealed(&self, node: NodeIndex) -> bool {
         let mut q = std::collections::VecDeque::new();
         q.push_back(node);
 
@@ -466,7 +459,13 @@ impl LocalsGraph {
         xs.sort_unstable_by(|a, b| a.n.cmp(&b.n));
         xs.dedup_by_key(|x| x.n);
 
-        for X { n, tag, sealed, vars } in xs {
+        for X {
+            n,
+            tag,
+            sealed,
+            vars,
+        } in xs
+        {
             writeln!(s, r#"    [{},"{tag}",{sealed},"{vars}"]"#, n.index())?;
         }
 

--- a/ogma/src/eng/mod.rs
+++ b/ogma/src/eng/mod.rs
@@ -24,8 +24,6 @@ pub(crate) use self::{
 
 pub use self::comp::{compile, FullCompilation};
 
-type Chgs<'a> = &'a mut Vec<graphs::Chg>;
-
 // ###### COMPILER #############################################################
 /// Ogma expression compiler.
 #[derive(Clone)]
@@ -87,6 +85,17 @@ pub struct Block<'a> {
     /// Only 255 arguments are supported.
     args_count: u8,
 
+    chgs: &'a mut Chgs,
+
+    /// Carry information about an asserted output type.
+    /// Check this against upon finalisation to ensure it matches.
+    /// Only available and checked in debug builds.
+    #[cfg(debug_assertions)]
+    output_ty: Option<Type>,
+}
+
+#[derive(Default)]
+pub struct Chgs {
     /// A list of changes to be made to the type graph.
     ///
     /// This is stored as a mutable reference since the block is usually passed by value to
@@ -94,16 +103,11 @@ pub struct Block<'a> {
     /// Any items here are actioned by the compiler to update the type graph, providing more
     /// information to conduct the type inferencing.
     /// This allows for block compilation to fail but the updates still be applied.
-    chgs: &'a mut Vec<graphs::Chg>,
-
+    chgs: Vec<graphs::Chg>,
     /// Flag that this block's output should be inferred if getting to output inferencing phase.
-    infer_output: &'a mut bool,
-
-    /// Carry information about an asserted output type.
-    /// Check this against upon finalisation to ensure it matches.
-    /// Only available and checked in debug builds.
-    #[cfg(debug_assertions)]
-    output_ty: Option<Type>,
+    infer_output: bool,
+    /// Flag that this op would introduce variables.
+    adds_vars: bool
 }
 
 // ###### STEP #################################################################
@@ -135,7 +139,7 @@ mod tests {
         // Although block sizing is large, it would not really be a hot spot, and the cost of
         // refactoring somewhat outweighs any benefit, without doing any proper profiling to
         // support it.
-        assert_eq!(size_of::<Block>(), 96 + size_of::<Option<Type>>()); // `output_ty` is only on debug builds
+        assert_eq!(size_of::<Block>(), 88 + size_of::<Option<Type>>()); // `output_ty` is only on debug builds
         assert_eq!(size_of::<Step>(), 32);
     }
 }

--- a/ogma/src/eng/mod.rs
+++ b/ogma/src/eng/mod.rs
@@ -94,6 +94,10 @@ pub struct Block<'a> {
     output_ty: Option<Type>,
 }
 
+/// Compiler changes to apply.
+///
+/// These changes are kept separate to the compiler state and are applied given the blocks partial
+/// compilation.
 #[derive(Default)]
 pub struct Chgs {
     /// A list of changes to be made to the type graph.
@@ -107,7 +111,7 @@ pub struct Chgs {
     /// Flag that this block's output should be inferred if getting to output inferencing phase.
     infer_output: bool,
     /// Flag that this op would introduce variables.
-    adds_vars: bool
+    adds_vars: bool,
 }
 
 // ###### STEP #################################################################

--- a/ogma/src/eng/var.rs
+++ b/ogma/src/eng/var.rs
@@ -1,6 +1,6 @@
 use super::*;
-use ::libs::divvy::Str;
 use graphs::ArgNode;
+use libs::divvy::Str;
 use std::sync::Arc;
 
 // ###### VARIABLE #############################################################

--- a/ogma/src/lang/impls/intrinsics/morphism.rs
+++ b/ogma/src/lang/impls/intrinsics/morphism.rs
@@ -544,7 +544,11 @@ fn fold_table_intrinsic(mut blk: Block) -> Result<Step> {
     blk.assert_adds_vars(true);
     blk.assert_input(&Ty::Tab)?;
 
-    let seed = blk.next_arg()?.decouple_op_seal().supplied(Type::Nil)?.concrete()?;
+    let seed = blk
+        .next_arg()?
+        .decouple_op_seal()
+        .supplied(Type::Nil)?
+        .concrete()?;
     let out_ty = seed.out_ty().clone();
     blk.assert_output(out_ty.clone());
 

--- a/ogma/src/lang/impls/intrinsics/morphism.rs
+++ b/ogma/src/lang/impls/intrinsics/morphism.rs
@@ -541,13 +541,15 @@ the variable $row is available to query the table row"
 }
 
 fn fold_table_intrinsic(mut blk: Block) -> Result<Step> {
+    blk.assert_adds_vars(true);
     blk.assert_input(&Ty::Tab)?;
 
-    let seed = blk.next_arg()?.supplied(Type::Nil)?.concrete()?;
+    let seed = blk.next_arg()?.decouple_op_seal().supplied(Type::Nil)?.concrete()?;
     let out_ty = seed.out_ty().clone();
     blk.assert_output(out_ty.clone());
 
     let row_var = blk.inject_manual_var_next_arg("row", Ty::TabRow)?;
+    blk.assert_vars_added();
     let acc_expr = blk
         .next_arg()?
         .supplied(out_ty.clone())? // accumulator supplies seed type
@@ -864,8 +866,11 @@ struct MapTable {
 
 impl MapTable {
     fn map(mut blk: Block) -> Result<Step> {
+        blk.assert_adds_vars(true);
+
         let colarg = blk
             .next_arg()?
+            .decouple_op_seal()
             .supplied(Ty::Nil)?
             .returns(Ty::Str)?
             .concrete()?;
@@ -876,6 +881,7 @@ impl MapTable {
             .flatten();
 
         let row_var = blk.inject_manual_var_next_arg("row", Ty::TabRow)?;
+        blk.assert_vars_added();
 
         let transformation = blk.next_arg()?;
         let transformation = match (force_flag, ty_flag) {

--- a/ogma/src/lang/impls/intrinsics/pipeline.rs
+++ b/ogma/src/lang/impls/intrinsics/pipeline.rs
@@ -382,6 +382,8 @@ variables are scoped to within the expression they are defined"
 }
 
 fn let_intrinsic(mut blk: Block) -> Result<Step> {
+    blk.assert_adds_vars(false);
+
     type Binding = (eng::Variable, eng::Argument);
 
     // detect if the trailing argument is a command (expr) node
@@ -433,6 +435,8 @@ fn let_intrinsic(mut blk: Block) -> Result<Step> {
     } else {
         None
     };
+
+    blk.assert_vars_added();
 
     fn bind_vars(bindings: &[Binding], value: &Value, cx: &mut Context) -> Result<()> {
         for (var, e) in bindings {

--- a/ogma/tests/commands/pipeline.rs
+++ b/ogma/tests/commands/pipeline.rs
@@ -777,6 +777,41 @@ fn not_enough_let_params() {
     );
 }
 
+#[test]
+fn variable_shadowing_soundness_01() {
+    let defs = &Definitions::new();
+    let code = "ls | let $x | + { let 'hdr' $x | Table $x }";
+    let x = process_w_nil(code, defs);
+
+    if let Err(e) = &x {
+        println!("{e}");
+    }
+
+    assert!(matches!(x, Ok(Value::Tab(_))));
+
+    let code = r#"ls | let $x | map size {:Num let $row.type:Str $x | Table $x }"#;
+    let x = process_w_nil(code, defs);
+
+    if let Err(e) = &x {
+        println!("{e}");
+    }
+
+    assert!(matches!(x, Ok(Value::Tab(_))));
+}
+
+#[test]
+fn variable_shadowing_soundness_02() {
+    let defs = &Definitions::new();
+    let code = r#"ls | let $x | grp type | map value {:Table \ $x | let $row.key:Str $x | fold {Table $x} append-row $row.size:Num  }"#;
+    let x = process_w_nil(code, defs);
+
+    if let Err(e) = &x {
+        println!("{e}");
+    }
+
+    assert!(matches!(x, Ok(Value::Tab(_))));
+}
+
 // ------ Nth ------------------------------------------------------------------
 #[test]
 fn nth_help_msg() {


### PR DESCRIPTION
Fixes an uncommon variable shadowing robustness bug by reworking the compiler's knowledge about variables to a more pessimistic default.