### PR TITLE
No panic on inference depth

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,26 +1,9 @@
 **🛑 Breaking Changes**
 
 **🔬 New Features**
-- Improve help messages for defs with multiple input types
-    (https://github.com/kdr-aus/ogma/pull/134)
-- The shell supports themes and transparent terminal backgrounds
-    (https://github.com/kdr-aus/ogma/pull/153)
 
 **🐛 Bug Fixes**
-- Fix variable type inferencing when passing variables to `def`s (https://github.com/kdr-aus/ogma/pull/115)
-- Detect trailing command in `let` and suggest a pipe (https://github.com/kdr-aus/ogma/pull/113)
-- Fix error where stronger type guarantees were present (https://github.com/kdr-aus/ogma/pull/117)
-- Fix def not inferring correct input in `last` (https://github.com/kdr-aus/ogma/pull/147)
-- Fix _locals graph needs updating_ bug (https://github.com/kdr-aus/ogma/pull/148)
-- Provide more verbose parsing errors (https://github.com/kdr-aus/ogma/pull/151)
-- Fix CPU spinning with completion prompt open (https://github.com/kdr-aus/ogma/pull/152)
-- Fix an uncommon variable shadowing bug by reworking the variable sealing system
-    (https://github.com/kdr-aus/ogma/pull/154)
+- Reaching an inference depth will now present an error suggesting to annotate types rather than
+    panic (https://github.com/kdr-aus/ogma/pull/159)
 
 **✨ Other Updates**
-- `ogma` crate API documentation is now published at https://kdr-aus.github.io/ogma/ogma/ (https://github.com/kdr-aus/ogma/commit/cf5cc7979c399b609e2e0605ffe176e70e474ac2)
-- Improve help messages and back end def input type matching
-    (https://github.com/kdr-aus/ogma/pull/141)
-- Introduce `TypesSet`s into the inferencer (https://github.com/kdr-aus/ogma/pull/144)
-- Fully move to `TypesSets` for more robust type inference
-    (https://github.com/kdr-aus/ogma/pull/145)

--- a/ogma-shell/interface/mod.rs
+++ b/ogma-shell/interface/mod.rs
@@ -951,7 +951,7 @@ fn cnv_span(s: &str, slice: self::cansi::CategorisedSlice, theme: u8) -> Span<'s
         style = style.add_modifier(Modifier::CROSSED_OUT);
     }
 
-    Span::styled(String::from(s), style.theme(theme))
+    Span::styled(String::from(s.replace('\t', "    ")), style.theme(theme))
 }
 
 fn cnv_colour(c: self::cansi::Color) -> Color {

--- a/ogma-shell/interface/mod.rs
+++ b/ogma-shell/interface/mod.rs
@@ -951,7 +951,7 @@ fn cnv_span(s: &str, slice: self::cansi::CategorisedSlice, theme: u8) -> Span<'s
         style = style.add_modifier(Modifier::CROSSED_OUT);
     }
 
-    Span::styled(String::from(s.replace('\t', "    ")), style.theme(theme))
+    Span::styled(s.replace('\t', "    "), style.theme(theme))
 }
 
 fn cnv_colour(c: self::cansi::Color) -> Color {

--- a/ogma/src/common/err.rs
+++ b/ogma/src/common/err.rs
@@ -566,8 +566,12 @@ Please supply this BACKTRACE:
     /// Use this to bubble an inference depth reached error.
     pub(crate) fn inference_depth() -> Self {
         Self {
+            cat: Category::Type,
             desc: "inference depth reached".to_string(),
             hard: true,
+            help_msg: Some(
+                "try annotating the input and/or output types you are expecting".to_string(),
+            ),
             ..Default::default()
         }
     }

--- a/ogma/src/common/err.rs
+++ b/ogma/src/common/err.rs
@@ -576,6 +576,7 @@ Please supply this BACKTRACE:
         }
     }
 
+    /// Is this error because of reaching inference depth?
     pub fn is_inference_depth_error(&self) -> bool {
         self.desc.starts_with("inference depth reached")
     }

--- a/ogma/src/common/err.rs
+++ b/ogma/src/common/err.rs
@@ -562,6 +562,19 @@ Please supply this BACKTRACE:
         self.help_msg = Self::internal_err_help();
         self
     }
+
+    /// Use this to bubble an inference depth reached error.
+    pub(crate) fn inference_depth() -> Self {
+        Self {
+            desc: "inference depth reached".to_string(),
+            hard: true,
+            ..Default::default()
+        }
+    }
+
+    pub fn is_inference_depth_error(&self) -> bool {
+        self.desc.starts_with("inference depth reached")
+    }
 }
 
 /// Type Errors
@@ -989,5 +1002,11 @@ World
  |      ^
 "
         );
+    }
+
+    #[test]
+    fn chk_inference_depth() {
+        let e = Error::inference_depth();
+        assert!(e.is_inference_depth_error());
     }
 }

--- a/ogma/src/eng/blk.rs
+++ b/ogma/src/eng/blk.rs
@@ -218,6 +218,20 @@ impl<'a> Block<'a> {
             .ok_or_else(|| Error::insufficient_args(self.op_tag(), self.args_count, None))?;
         self.inject_manual_var_into_arg_locals(n, name, ty)
     }
+
+    /// Oblige the **remaining** arguments to have the input type `ty`.
+    ///
+    /// `ty` is similar to [`ArgBuilder::supplied`], where a `None` indicates to use the block's
+    /// input type.
+    /// 
+    /// This method does not pop any arguments, it merely flags to the compiler to insert type
+    /// graph changes.
+    pub fn oblige_args_supplied_tys<T: Into<Option<Type>>>(&mut self, ty: T) {
+        let t = ty.into().unwrap_or_else(|| self.in_ty.clone());
+        self.chgs.chgs.extend(self.args.iter().map(|arg| {
+            tygraph::Chg::ObligeInput(arg.idx(), t.clone()).into()
+        }));
+    }
 }
 
 /// Evalulation functions.

--- a/ogma/src/eng/blk.rs
+++ b/ogma/src/eng/blk.rs
@@ -223,14 +223,16 @@ impl<'a> Block<'a> {
     ///
     /// `ty` is similar to [`ArgBuilder::supplied`], where a `None` indicates to use the block's
     /// input type.
-    /// 
+    ///
     /// This method does not pop any arguments, it merely flags to the compiler to insert type
     /// graph changes.
     pub fn oblige_args_supplied_tys<T: Into<Option<Type>>>(&mut self, ty: T) {
         let t = ty.into().unwrap_or_else(|| self.in_ty.clone());
-        self.chgs.chgs.extend(self.args.iter().map(|arg| {
-            tygraph::Chg::ObligeInput(arg.idx(), t.clone()).into()
-        }));
+        self.chgs.chgs.extend(
+            self.args
+                .iter()
+                .map(|arg| tygraph::Chg::ObligeInput(arg.idx(), t.clone()).into()),
+        );
     }
 }
 

--- a/ogma/src/eng/comp/infer.rs
+++ b/ogma/src/eng/comp/infer.rs
@@ -184,7 +184,7 @@ impl<'d> Compiler<'d> {
     fn assert_inference_depth(&self) -> Result<()> {
         (self.inference_depth < 5)
             .then(|| ())
-            .ok_or_else(|| crate::Error::inference_depth())
+            .ok_or_else(crate::Error::inference_depth)
     }
 }
 
@@ -271,11 +271,7 @@ fn test_compile_types<'a>(
 
     let mut inferred = None;
 
-    _counts_line(format_args!("{node:?}"));
-
     for ty in types.iter() {
-        _counts_line(format_args!("{ty}"));
-
         let mut compiler: Compiler_ = compiler.clone();
         compiler.inference_depth += 1;
 
@@ -293,7 +289,6 @@ fn test_compile_types<'a>(
                 compiler.compile(breakon)
             }
             Err(_) => {
-                _counts_line(format_args!("failed to apply {ty} to {node:?}"));
                 rm.push(ty.clone());
                 continue;
             }

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -167,14 +167,6 @@ impl<'d> Compiler<'d> {
                 _ => (),
             }
 
-            match self.infer_inputs_expr() {
-                Ok(true) => continue,
-                // Break early if a hard error.
-                Err(e) if e.hard => return Err(e),
-                Err(e) => err = e,
-                _ => (),
-            }
-
             // return the output inference error here
             match self.infer_outputs() {
                 Ok(true) => continue,
@@ -183,6 +175,14 @@ impl<'d> Compiler<'d> {
                     _counts_line(format_args!("{}", self.inference_depth));
                     return Err(e);
                 }
+                Err(e) => err = e,
+                _ => (),
+            }
+
+            match self.infer_inputs_expr() {
+                Ok(true) => continue,
+                // Break early if a hard error.
+                Err(e) if e.hard => return Err(e),
                 Err(e) => err = e,
                 _ => (),
             }

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -123,11 +123,6 @@ impl<'d> Compiler<'d> {
     }
 
     fn compile<B: BreakOn>(mut self: Box<Self>, break_on: B) -> Result<Box<Self>> {
-        _counts_line(format_args!(
-            "Compiler::compile with {} depth",
-            self.inference_depth
-        ));
-
         let brk_key = &break_on.idx();
         while !(self.compiled_exprs.contains_key(brk_key)
             || self.compiled_ops.contains_key(brk_key))
@@ -171,10 +166,7 @@ impl<'d> Compiler<'d> {
             match self.infer_outputs() {
                 Ok(true) => continue,
                 // Break early if a hard error.
-                Err(e) if e.hard => {
-                    _counts_line(format_args!("{}", self.inference_depth));
-                    return Err(e);
-                }
+                Err(e) if e.hard => return Err(e),
                 Err(e) => err = e,
                 _ => (),
             }

--- a/ogma/src/eng/graphs/tygraph.rs
+++ b/ogma/src/eng/graphs/tygraph.rs
@@ -46,6 +46,7 @@ pub enum Chg {
     AnyInput(NodeIndex),
     KnownOutput(NodeIndex, Type),
     ObligeOutput(NodeIndex, Type),
+    RemoveOutput(NodeIndex, Type),
     AddEdge {
         src: NodeIndex,
         dst: NodeIndex,
@@ -68,6 +69,7 @@ impl Chg {
             Chg::AnyInput(i) => i,
             Chg::KnownOutput(i, _) => i,
             Chg::ObligeOutput(i, _) => i,
+            Chg::RemoveOutput(i, _) => i,
             Chg::AddEdge {
                 src,
                 dst: _,
@@ -594,6 +596,7 @@ impl TypeGraph {
             Chg::ObligeOutput(node, ty) => {
                 apply(self, node, |n| set(&mut n.output, Knowledge::Obliged(ty)))
             }
+            Chg::RemoveOutput(node, ty) => apply(self, node, |n| Ok(n.output.rm_inferred(&ty))),
             Chg::AddEdge { src, dst, flow } => {
                 // TODO edges_connecting is not implemented yet for StableGraph
                 // can be replicated with a filter

--- a/ogma/src/eng/mod.rs
+++ b/ogma/src/eng/mod.rs
@@ -38,8 +38,8 @@ pub struct Compiler<'d> {
     compiled_ops: IndexMap<Step>,
     /// A map of **Expr** nodes which have succesfully compiled into an evaluation stack.
     compiled_exprs: IndexMap<eval::Stack>,
-    /// A op node which has been flag for output inference.
-    output_infer_opnode: Option<graphs::OpNode>,
+    /// Op nodes which have been flagged for output inference.
+    output_infer_opnodes: Vec<graphs::OpNode>,
     /// A map of **Def** nodes which have had their call site parameters prepared as variables.
     callsite_params: IndexMap<Vec<comp::CallsiteParam>>,
     /// Depth limit of inference to loop down to.

--- a/ogma/src/eng/mod.rs
+++ b/ogma/src/eng/mod.rs
@@ -137,7 +137,7 @@ mod tests {
     fn structures_sizing() {
         use std::mem::size_of;
 
-        assert_eq!(size_of::<Compiler>(), 408); // oomph! this is why we hide it behind Box<Compiler>
+        assert_eq!(size_of::<Compiler>(), 424); // oomph! this is why we hide it behind Box<Compiler>
 
         // NOTE
         // Although block sizing is large, it would not really be a hot spot, and the cost of

--- a/ogma/src/lang/impls/intrinsics/mod.rs
+++ b/ogma/src/lang/impls/intrinsics/mod.rs
@@ -77,10 +77,7 @@ where
 {
     let ty = T::as_type();
 
-    if blk.in_ty() != &ty {
-        return Err(Error::wrong_op_input_type(blk.in_ty(), blk.op_tag()));
-    }
-
+    blk.assert_input(&ty)?;
     blk.assert_output(ty.clone());
 
     let len = blk.args_len();
@@ -91,6 +88,9 @@ where
     }
 
     let args = {
+        // notice that each arg will be supplied input type!
+        blk.oblige_args_supplied_tys(None);
+
         let mut a = Vec::with_capacity(len);
         for _ in 0..len {
             // use blocks input type

--- a/ogma/src/lang/impls/intrinsics/morphism.rs
+++ b/ogma/src/lang/impls/intrinsics/morphism.rs
@@ -66,6 +66,7 @@ fn append_table_intrinsic(mut blk: Block) -> Result<Step> {
         return Err(Error::insufficient_args(blk.blk_tag(), 0, None));
     }
 
+    blk.oblige_args_supplied_tys(Ty::TabRow); // each argument will be supplied a TableRow
     let mut cols = Vec::with_capacity(len);
     let mut auto = 1;
     for _ in 0..len {
@@ -147,6 +148,9 @@ the row is populated with the expression results",
 fn append_row_intrinsic(mut blk: Block) -> Result<Step> {
     blk.assert_input(&Ty::Tab)?;
     blk.assert_output(Ty::Tab);
+
+    // each argument will be supplied the input type
+    blk.oblige_args_supplied_tys(None);
 
     let len = blk.args_len();
     let mut cols = Vec::with_capacity(len);

--- a/ogma/src/lang/impls/intrinsics/pipeline.rs
+++ b/ogma/src/lang/impls/intrinsics/pipeline.rs
@@ -383,6 +383,7 @@ variables are scoped to within the expression they are defined"
 
 fn let_intrinsic(mut blk: Block) -> Result<Step> {
     blk.assert_adds_vars(false);
+    blk.assert_output(blk.in_ty().clone()); // let always passes through the input
 
     type Binding = (eng::Variable, eng::Argument);
 
@@ -403,6 +404,7 @@ fn let_intrinsic(mut blk: Block) -> Result<Step> {
         });
 
     fn build_bindings(blk: &mut Block) -> Result<Vec<Binding>> {
+        blk.oblige_args_supplied_tys(None); // we cheat a little bit here, arg nodes do not need to be obliged
         let mut bindings = Vec::with_capacity(blk.args_len() / 2);
         while blk.args_len() > 1 {
             let e = blk.next_arg()?.supplied(None)?.concrete()?;

--- a/ogma/tests/commands/pipeline.rs
+++ b/ogma/tests/commands/pipeline.rs
@@ -89,13 +89,11 @@ fn dotop_identifier_tests() {
     println!("{}", err);
     assert_eq!(
         err,
-        "Typing Error: Type resolution failed. Conflicting obligation type
+        "Semantics Error: expecting argument with output type `Number`, found `String`
 --> shell:27
  | fold 0 + $row.Testing-weird\\string
- |                            ^ this node returns a `String`
---> shell:27
- | fold 0 + $row.Testing-weird\\string
- |                            ^^^^^^^ but this node is obliged to return `Number`
+ |                            ^^^^^^^ this argument returns type `String`
+--> help: commands may require specific argument types, use `--help` to view requirements
 "
     );
 }


### PR DESCRIPTION
Removes the panic when reaching inference depth, instead opting to return a error message suggesting that the user annotate the ambiguous type.