### PR TITLE
Fix typos

### DIFF
--- a/docs/04 Common Commands.md
+++ b/docs/04 Common Commands.md
@@ -92,7 +92,7 @@ def eq Point (rhs) { and {get x | = $rhs.x} {get y | = $rhs.y} }
 
 > This pattern extends for other commands, a good example is the `sort-by` command.
 
-> Boolean logic such as AND and OR is done with a prefix `and` and `or` comand. Both are variadic
+> Boolean logic such as AND and OR is done with a prefix `and` and `or` command. Both are variadic
 > such that a logical expression can look like `\ 5 | or {= 3} {= 2} {= 5}`.
 
 ## Get
@@ -206,7 +206,7 @@ sizes. Use `+ --help` to view these details.
 ## Sorting and grouping
 ---
 Sorting can be done using two commands. `sort` takes column headers and sorts the entries **_in a
-canoncial fashion_** (this means entry _types_ have _order_ enforced on them). In general, `sort`
+canonical fashion_** (this means entry _types_ have _order_ enforced on them). In general, `sort`
 is the 'go to' sorting command. The sort help shows how specifying more than one header can be
 used to do 'then by' sorting.
 

--- a/docs/08 REPL and CLI/8.1 REPL.md
+++ b/docs/08 REPL and CLI/8.1 REPL.md
@@ -16,7 +16,7 @@ _Hint: To add a new line in the REPL, use `Alt+Return`._
 
 ## `cd` - Change working directory
 ---
-The command `cd` changes the working directory by navigating to the path specfied. For
+The command `cd` changes the working directory by navigating to the path specified. For
 instance, if one is working at the root level, then uses `cd foo`, the REPL will navigate
 to the folder `foo` (if it exists). The prompt also changes to reflect the working
 directory. To navigate **up** a level, use `..`.

--- a/docs/08 REPL and CLI/8.2 CLI.md
+++ b/docs/08 REPL and CLI/8.2 CLI.md
@@ -3,7 +3,7 @@
 # Command Line Interface (CLI)
 
 When the ogma binary is run with no arguments, a vanilla REPL is started.
-This is the most common use of ogma, however the CLI has optional paramters which can be used to
+This is the most common use of ogma, however the CLI has optional parameters which can be used to
 alter this behaviour. To view these parameters use `ogma --help` in your terminal.
 
 ## Definition Files

--- a/docs/15 Examples/15.3 Calculating Pi.md
+++ b/docs/15 Examples/15.3 Calculating Pi.md
@@ -44,7 +44,7 @@ def is-inside-circle Sample () { if {and {get x|=0} {get y|=0}} #t {mag | <= 1} 
 
 # Build a table of samples and flag if inside or not of circle.
 # Not strictly necessary but is a good way of building up to the solution
-# and checking everthing works.
+# and checking everything works.
 def build-samples Num () { range 0 #i |
     append --'sample point' sample |
     append --'inside' { get --Sample 'sample point' | is-inside-circle }

--- a/ogma-ls/completion.rs
+++ b/ogma-ls/completion.rs
@@ -223,7 +223,7 @@ pub struct Incomplete {
 
 /// A rudimentary AST node.
 pub struct Node {
-    /// The soure slice tag.
+    /// The source slice tag.
     pub tag: Tag,
     /// The language server defined kind (possibly different to the `ogma` kind).
     pub ty: NodeType,

--- a/ogma-ls/workspace.rs
+++ b/ogma-ls/workspace.rs
@@ -125,7 +125,7 @@ impl Workspace {
     /// Runs a clearing of all definitions before loading.
     ///
     /// > This loads what the contents of what is in the virtual file map. If using through a
-    /// > terminal where `def --load` can be called it is recommneded to just share the
+    /// > terminal where `def --load` can be called it is recommended to just share the
     /// > `Definitions` file and not use this method.
     pub(crate) fn def_load(&self) {
         let files = self.files.read();

--- a/ogma-shell/interface/outputs.rs
+++ b/ogma-shell/interface/outputs.rs
@@ -36,7 +36,7 @@ impl Outputs {
     }
 
     pub fn add(&mut self, value: String, theme: u8) {
-        let w = self.cached_width.saturating_sub(1) as usize; // one coloumn for the scroll bar
+        let w = self.cached_width.saturating_sub(1) as usize; // one column for the scroll bar
         let cached = super::convert_coloured_str(&value, w, theme);
         self.items.push_back(Output { cached, value });
         self.scroll = 0;
@@ -49,7 +49,7 @@ impl Outputs {
     pub fn update_width(&mut self, width: u16, theme: u8) {
         self.scroll = 0;
         self.cached_width = width;
-        let w = width.saturating_sub(1) as usize; // one coloumn for the scroll bar
+        let w = width.saturating_sub(1) as usize; // one column for the scroll bar
         for item in &mut self.items {
             item.cached = super::convert_coloured_str(&item.value, w, theme);
         }

--- a/ogma/src/common/err.rs
+++ b/ogma/src/common/err.rs
@@ -59,9 +59,9 @@ pub struct Error {
     pub traces: Vec<Trace>,
     /// Optional help message.
     pub help_msg: Option<String>,
-    /// Error should propogate immediately.
+    /// Error should propagate immediately.
     ///
-    /// This is a flag to the compiler that the error should be propogated through, exiting the
+    /// This is a flag to the compiler that the error should be propagated through, exiting the
     /// compiling loop early without further compilation processes.
     /// This is usually done when a error is encountered that is unrelated to typing issues, and
     /// will be an error even if _all_ type information was known.
@@ -223,7 +223,7 @@ impl Error {
                 "implementation of `{}` not defined for input type `{}`",
                 op, in_ty
             ),
-            traces: trace(op, format!("`{}` not implmented for `{}` input", op, in_ty)),
+            traces: trace(op, format!("`{}` not implemented for `{}` input", op, in_ty)),
             help_msg: Some("view a list of definitions using `def --list`".into()),
             ..Self::default()
         }
@@ -840,7 +840,7 @@ fn trace_code_lines(code: &str, start: usize, end: usize) -> Vec<(&str, usize, u
 }
 
 // ###### STRUCTS ##############################################################
-/// Error catgories.
+/// Error categories.
 #[derive(Debug, PartialEq)]
 pub enum Category {
     /// Internal error. These should not occur.

--- a/ogma/src/eng/comp/infer.rs
+++ b/ogma/src/eng/comp/infer.rs
@@ -404,7 +404,7 @@ impl Error {
     /// to provide good error messages, the _last_ in the bubbling should be the
     /// _first_ displayed.
     /// So we take the head from the trace list, copy the message, set the old
-    /// message to be just a trace stack message, and we will end up with tthe
+    /// message to be just a trace stack message, and we will end up with the
     /// shallowest node on top
     fn add_trace(mut e: crate::Error, tag: &Tag, msg: impl Into<String>) -> crate::Error {
         if e.traces.is_empty() {

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -414,14 +414,14 @@ impl<'d> Compiler<'d> {
                         .filter_map(|n| self.ag[n].def().map(|_| DefNode(n)))
                         // get the parent op
                         .map(|def| def.parent(&self.ag))
-                        // use the block tage as the trace
+                        // use the block tag as the trace
                         .map(|op| op.blk_tag(&self.ag));
 
                     for parent in parents {
                         e = e.add_trace(parent, None);
                     }
 
-                    // update the error, with hard errors taking precendence!
+                    // update the error, with hard errors taking precedence!
                     err = match (err.take(), e) {
                         // the new error is hard, it trumps all
                         (_, b) if b.hard => Some(b),
@@ -442,7 +442,7 @@ impl<'d> Compiler<'d> {
 
         (goto_resolve | chgd)
             .then(|| ())
-            .ok_or_else(|| err.expect("error should be some if unsuccesful"))
+            .ok_or_else(|| err.expect("error should be some if unsuccessful"))
     }
 
     /// Try to compile `opnode` into an evaluation [`Step`] given the input type (`in_ty`).
@@ -479,7 +479,7 @@ impl<'d> Compiler<'d> {
                             .output
                             .ty()
                             .cloned()
-                            .expect("shoud be known if a stack exists");
+                            .expect("should be known if a stack exists");
                         Ok(Step::def(params, stack.clone(), out_ty))
                     }
                     None => {

--- a/ogma/src/eng/comp/params.rs
+++ b/ogma/src/eng/comp/params.rs
@@ -49,7 +49,7 @@ impl<'d> Compiler<'d> {
                     );
 
                     // seal off the def's expr node
-                    // no more changes should occur since we have had succcess building.
+                    // no more changes should occur since we have had success building.
                     self.lg.seal(def.expr(&self.ag));
                 }
                 LocalInjection::UnknownReturnTy(_) => {

--- a/ogma/src/eng/comp/resolve_tg.rs
+++ b/ogma/src/eng/comp/resolve_tg.rs
@@ -187,7 +187,7 @@ impl<'d> Compiler<'d> {
 
         let node = self.ag[node].tag();
 
-        let appliction = match &conflict {
+        let application = match &conflict {
             UnknownSrc => {
                 Trace::from_tag(node, "this node's type is specified as unknown".to_string())
             }
@@ -235,7 +235,7 @@ impl<'d> Compiler<'d> {
             )),
         };
 
-        err.traces.push(appliction);
+        err.traces.push(application);
         if let Some(e) = exists {
             err.traces.push(e);
         }

--- a/ogma/src/eng/graphs/locals_graph.rs
+++ b/ogma/src/eng/graphs/locals_graph.rs
@@ -285,7 +285,7 @@ impl LocalsGraph {
                 defined_at,
             } => {
                 self.add_new_var(name, ty, tag, defined_at);
-                self.flow(defined_at); // propogate change
+                self.flow(defined_at); // propagate change
                 true // graph altered
             }
             Chg::NewLazy {
@@ -295,7 +295,7 @@ impl LocalsGraph {
                 defined_at,
             } => {
                 self.add_new_lazy(name, to, tag, defined_at);
-                self.flow(defined_at); // propogate change
+                self.flow(defined_at); // propagate change
                 true // graph altered
             }
             Chg::Seal(op) => {

--- a/ogma/src/eng/graphs/tygraph.rs
+++ b/ogma/src/eng/graphs/tygraph.rs
@@ -366,8 +366,8 @@ impl TypeGraph {
                 }
             });
 
-            if let Some(contrained) = keys {
-                self.g[op.idx()].input = contrained.into();
+            if let Some(constrained) = keys {
+                self.g[op.idx()].input = constrained.into();
             }
         }
     }

--- a/ogma/src/eng/mod.rs
+++ b/ogma/src/eng/mod.rs
@@ -34,9 +34,9 @@ pub struct Compiler<'d> {
     lg: graphs::locals_graph::LocalsGraph,
     /// The edges in the `tg` that have been resolved and flowed.
     flowed_edges: IndexSet,
-    /// A map of **Op** nodes which have succesfully compiled into a `Step`.
+    /// A map of **Op** nodes which have successfully compiled into a `Step`.
     compiled_ops: IndexMap<Step>,
-    /// A map of **Expr** nodes which have succesfully compiled into an evaluation stack.
+    /// A map of **Expr** nodes which have successfully compiled into an evaluation stack.
     compiled_exprs: IndexMap<eval::Stack>,
     /// Op nodes which have been flagged for output inference.
     output_infer_opnodes: Vec<graphs::OpNode>,
@@ -46,7 +46,7 @@ pub struct Compiler<'d> {
     inference_depth: u32,
 }
 
-/// Boxed compiler, should be used when passsing by value.
+/// Boxed compiler, should be used when passing by value.
 type Compiler_<'a> = Box<Compiler<'a>>;
 
 // ###### BLOCK ################################################################

--- a/ogma/src/eng/var.rs
+++ b/ogma/src/eng/var.rs
@@ -31,7 +31,7 @@ impl Environment {
         let arc: &mut Arc<_> = &mut self.0;
 
         // we can't just use get_mut since using `return` seems to not work with lifetimes
-        // instead, we check the counts outselves.
+        // instead, we check the counts ourselves.
         // we use the assumption that counts of one would be unique along this thread, and since
         // there cannot be another Arc on another thread without having counts > 1, this arc is
         // unique

--- a/ogma/src/lang/defs.rs
+++ b/ogma/src/lang/defs.rs
@@ -85,7 +85,7 @@ impl Definitions {
             "test if input is greater than or equal to rhs",
             vec![
                 HelpExample {
-                    desc: "test if 1 againt 0",
+                    desc: "test if 1 against 0",
                     code: "\\ 1 | >= 0",
                 },
                 HelpExample {
@@ -117,7 +117,7 @@ impl Definitions {
             "test if input is less than or equal to rhs",
             vec![
                 HelpExample {
-                    desc: "test if 1 againt 0",
+                    desc: "test if 1 against 0",
                     code: "\\ 1 | <= 0",
                 },
                 HelpExample {
@@ -265,7 +265,7 @@ pub fn recognise_definition(s: &str) -> bool {
 
 type DefResult<'a> = Result<(Value, Option<&'a str>)>;
 
-/// Process an expression whichs defines a _definition_.
+/// Process an expression which defines a _definition_.
 ///
 /// If successful the definition will be added to `defs`.
 ///

--- a/ogma/src/lang/impls/intrinsics/mod.rs
+++ b/ogma/src/lang/impls/intrinsics/mod.rs
@@ -216,7 +216,7 @@ fn type_flag(blk: &mut Block) -> Result<Option<Type>> {
 /// 1. `buf` should **have equal or less length than table rows**
 /// 2. The first element is skipped over (table header row)
 /// 3. The callback should use `*T = foo` to update-in-place.
-/// 4. Errors should be propogated through.
+/// 4. Errors should be propagated through.
 ///
 /// This method utilises `rayon`'s `for_each_init` to seed the colmap amongst workers.
 fn par_over_tablerows<T, F>(buf: &mut [T], table: &Table, cx: &Context, f: F) -> Result<()>

--- a/ogma/src/lang/impls/intrinsics/pipeline.rs
+++ b/ogma/src/lang/impls/intrinsics/pipeline.rs
@@ -9,7 +9,7 @@ pub fn add_intrinsics(impls: &mut Implementations) {
         (
             ".",
             None,
-            ast::DotOperatorBlock::instrinsic,
+            ast::DotOperatorBlock::intrinsic,
             Pipeline,
             ast::DotOperatorBlock::help
         )
@@ -229,7 +229,7 @@ impl ast::DotOperatorBlock {
 
     /// Consists of 2 terms: `input.field`.
     /// For TableRow input we handle separately
-    fn instrinsic(mut blk: Block) -> Result<Step> {
+    fn intrinsic(mut blk: Block) -> Result<Step> {
         let input = blk.next_arg()?.supplied(None)?.concrete()?;
         let field = blk.next_arg()?.supplied(Ty::Nil)?;
         match input.out_ty() {

--- a/ogma/src/lang/syntax/ast.rs
+++ b/ogma/src/lang/syntax/ast.rs
@@ -199,7 +199,7 @@ pub trait IBlock: std::fmt::Debug + Send + Sync {
     fn terms(&self) -> Cow<[Term]>;
     /// An optional annotated input type constraint.
     fn in_ty(&self) -> Option<CTag>;
-    /// An optional annotated ouput type constraint.
+    /// An optional annotated output type constraint.
     fn out_ty(&self) -> Option<CTag>;
 
     /// Create a tag that extends across the whole block.

--- a/ogma/src/lang/types.rs
+++ b/ogma/src/lang/types.rs
@@ -232,7 +232,7 @@ impl From<$type> for Value {
 
 prim_type_impls!(bool=>Bool, Number=>Num, Str=>Str, Table=>Tab, TableRow=>TabRow);
 
-// ----- additionals that don't fit pattern -----
+// ----- additional that don't fit pattern -----
 impl AsType for () {
     fn as_type() -> Type {
         Type::Nil
@@ -737,7 +737,7 @@ impl TableRow {
         }
     }
 
-    /// Retrive an entry at `(row, col)`. Use if _rowidx_ and _colidx_ are known an can be
+    /// Retrieve an entry at `(row, col)`. Use if _rowidx_ and _colidx_ are known an can be
     /// memoized.
     ///
     /// # Panics


### PR DESCRIPTION
Found via this command:

    codespell -L crate,fo,frist,ser,froms