### PR TITLE
Extend `PolyGet` API

### DIFF
--- a/ogma/src/lang/defs2/mod.rs
+++ b/ogma/src/lang/defs2/mod.rs
@@ -130,13 +130,6 @@ fn parse_file(file: PathBuf) -> Result<File> {
 pub trait PolyGet<R> {
     /// The output type (ie `Option<R>` or `Result<R, Error>`).
     type Output;
-    type Meta: ?Sized;
-
-    /// There needs to be a common key which is used.
-    fn key(&self) -> &str;
-
-    /// Retrieve the meta data.
-    fn meta(&self) -> &Self::Meta;
 
     /// Wrap a successful get.
     fn success(r: R) -> Self::Output;
@@ -150,28 +143,29 @@ pub trait PolyGet<R> {
         E: FnOnce(&Tag) -> Error;
 }
 
+pub trait AsKey<K> {
+    fn as_key(&self) -> K;
+}
+
 /// Consistent access API of definition items.
-pub trait DefItems<Key> {
+pub trait DefItems<'a, Key: 'a> {
     type Item;
     type Iter: Iterator;
 
     /// Contains the item under key.
-    ///
-    /// If `within` is not known, the search can be conducted from the root node using [`ROOT`].
-    fn contains<N: Into<Id>>(&self, key: &str, within: N) -> bool;
+    fn contains<K>(&self, key: K) -> bool
+    where
+        K: AsKey<Key>;
 
     /// Get the item under key.
-    ///
-    /// If `within` is not known, the search can be conducted from the root node using [`ROOT`].
-    fn get<'a, K, N: Into<Id>>(&'a self, key: &K, within: N) -> K::Output
+    fn get<K>(&self, key: K) -> K::Output
     where
-        K: PolyGet<&'a Self::Item, Meta = Key>,
-        K: ?Sized;
+        K: PolyGet<Self::Item> + AsKey<Key>;
 
     /// Get the item's help under key.
-    fn help<K>(&self, key: &K) -> K::Output
+    fn help<K>(&self, key: K) -> K::Output
     where
-        K: PolyGet<Error>;
+        K: PolyGet<Error> + AsKey<Key>;
 
     /// Return an iterator over all the items.
     fn iter(&self) -> Self::Iter;
@@ -181,11 +175,16 @@ pub struct Impls<'a>(&'a Definitions);
 
 pub struct Types<'a>(&'a Definitions);
 
-impl<'a> DefItems<Type> for Impls<'a> {
-    type Item = Implementation;
-    type Iter = ImplsIter;
+impl<'a> Impls<'a> {
+    pub fn within<N: Into<Id>>(self, partition: N) -> ImplsIn<'a> {
+        ImplsIn {
+            impls: self,
+            partition: partition.into(),
+        }
+    }
 
-    fn contains<N: Into<Id>>(&self, key: &str, within: N) -> bool {
+    /// Does not check for type matching, see [`contains`] instead.
+    pub fn contains_op(&self, key: &str, within: Id) -> bool {
         let (bnd, imports) = self.0.partitions.bnd_and_imports(within);
         self.0
             .partitions
@@ -193,18 +192,24 @@ impl<'a> DefItems<Type> for Impls<'a> {
             .any(|_| true)
     }
 
-    fn get<'b, K, N: Into<Id>>(&'b self, key: &K, within: N) -> K::Output
+    fn contains_(&self, key: &str, ty: &Type, within: Id) -> bool {
+        let (bnd, imports) = self.0.partitions.bnd_and_imports(within);
+        self.0
+            .partitions
+            .find_impls(bnd, imports, key)
+            .any(|x| self.0.impls[&x].0.as_ref() == Some(ty))
+    }
+
+    fn get_<K>(&self, key: &str, ty: &Type, within: Id, k_: K) -> K::Output
     where
-        K: PolyGet<&'b Self::Item, Meta = Type>,
-        K: ?Sized,
+        K: PolyGet<&'a Implementation>
     {
         let (bnd, imports) = self.0.partitions.bnd_and_imports(within);
 
+        let chk_ty = ty;
         let mut ambig = None;
         let mut found = None;
-        let chk_ty = key.meta();
-        let key_ = key.key();
-        for n in self.0.partitions.find_impls(bnd, imports, key_) {
+        for n in self.0.partitions.find_impls(bnd, imports, key) {
             let (ty, impl_) = self
                 .0
                 .impls
@@ -213,7 +218,7 @@ impl<'a> DefItems<Type> for Impls<'a> {
             match ty {
                 Some(ty) if ty == chk_ty => match found {
                     Some(_) => {
-                        return key.fail(|tag| {
+                        return k_.fail(|tag| {
                             Error {
                 cat: err::Category::Definitions,
                 desc: "ambiguous operation reference".to_string(),
@@ -228,7 +233,7 @@ impl<'a> DefItems<Type> for Impls<'a> {
                 Some(_) => (), // skip, type doesn't match
                 None => match ambig {
                     Some(_) => {
-                        return key.fail(|tag| {
+                        return k_.fail(|tag| {
                             Error {
                 cat: err::Category::Definitions,
                 desc: "ambiguous operation reference".to_string(),
@@ -245,27 +250,20 @@ impl<'a> DefItems<Type> for Impls<'a> {
 
         match (found, ambig) {
             (Some(x), _) | (None, Some(x)) => K::success(x),
-            (None, None) => key.fail(|tag| Error::impl_not_found(tag, chk_ty)),
+            (None, None) => k_.fail(|tag| Error::impl_not_found(tag, chk_ty)),
         }
-    }
-
-    fn help<K>(&self, _key: &K) -> K::Output
-    where
-        K: PolyGet<Error>,
-    {
-        todo!()
-    }
-
-    fn iter(&self) -> Self::Iter {
-        todo!()
     }
 }
 
-impl<'a> DefItems<()> for Types<'a> {
-    type Item = Type;
-    type Iter = TypesIter;
+impl<'a> Types<'a> {
+    pub fn within<N: Into<Id>>(self, partition: N) -> TypesIn<'a> {
+        TypesIn {
+            types: self,
+            partition: partition.into(),
+        }
+    }
 
-    fn contains<N: Into<Id>>(&self, key: &str, within: N) -> bool {
+    fn contains_(&self, key: &str, within: Id) -> bool {
         let (bnd, imports) = self.0.partitions.bnd_and_imports(within);
         self.0
             .partitions
@@ -273,18 +271,18 @@ impl<'a> DefItems<()> for Types<'a> {
             .any(|_| true)
     }
 
-    fn get<'b, K, N: Into<Id>>(&'b self, key: &K, within: N) -> K::Output
+    fn get_<S, F, O>(&self, key: &str, within: Id, succeed: S, fail: F) -> O
     where
-        K: PolyGet<&'b Self::Item>,
-        K: ?Sized,
+        F: FnOnce(fn(&Tag) -> Error) -> O,
+        S: FnOnce(&'a Type) -> O,
     {
         let (bnd, imports) = self.0.partitions.bnd_and_imports(within);
 
-        let mut x = self.0.partitions.find_types(bnd, imports, key.key());
+        let mut x = self.0.partitions.find_types(bnd, imports, key);
         let y = x.next();
 
         if x.next().is_some() {
-            return key.fail(|tag| Error {
+            return fail(|tag| Error {
                 cat: err::Category::Definitions,
                 desc: "ambiguous type reference".to_string(),
                 traces: err::trace(tag, format!("{tag} references multiple definitions")),
@@ -297,19 +295,150 @@ impl<'a> DefItems<()> for Types<'a> {
         }
 
         match y {
-            Some(x) => K::success(
+            Some(x) => succeed(
                 self.0
                     .types
                     .get(&x)
                     .expect("Type should be initialised within map"),
             ),
-            None => key.fail(Error::type_not_found),
+            None => fail(Error::type_not_found),
         }
     }
+}
 
-    fn help<K>(&self, _key: &K) -> K::Output
+impl<'a, 'd> DefItems<'a, (&'a str, &'a Type, Id)> for Impls<'d> {
+    type Item = &'d Implementation;
+    type Iter = ImplsIter;
+
+    fn contains<K>(&self, key: K) -> bool
     where
-        K: PolyGet<Error>,
+        K: AsKey<(&'a str, &'a Type, Id)>,
+    {
+        let (k, t, w) = key.as_key();
+        self.contains_(k, t, w)
+    }
+
+    fn get<K>(&self, key: K) -> K::Output
+    where
+        K: PolyGet<Self::Item>,
+        K: AsKey<(&'a str, &'a Type, Id)>,
+    {
+        let (key_, chk_ty, within) = key.as_key();
+        self.get_(key_, chk_ty, within, key)
+    }
+
+    fn help<K>(&self, _key: K) -> K::Output
+    where
+        K: PolyGet<Error> + AsKey<(&'a str, &'a Type, Id)>,
+    {
+        todo!()
+    }
+
+    fn iter(&self) -> Self::Iter {
+        todo!()
+    }
+}
+
+impl<'a, 'd> DefItems<'a, (&'a str, Id)> for Types<'d> {
+    type Item = &'d Type;
+    type Iter = TypesIter;
+
+    fn contains<K>(&self, key: K) -> bool
+    where
+        K: AsKey<(&'a str, Id)>,
+    {
+        let (k, w) = key.as_key();
+        self.contains_(k, w)
+    }
+
+    fn get<K>(&self, key: K) -> K::Output
+    where
+        K: PolyGet<Self::Item>,
+        K: AsKey<(&'a str, Id)>,
+    {
+        let (key_, within) = key.as_key();
+        self.get_(key_, within, K::success, |f| key.fail(f))
+    }
+
+    fn help<K>(&self, _key: K) -> K::Output
+    where
+        K: PolyGet<Error> + AsKey<(&'a str, Id)>,
+    {
+        todo!()
+    }
+
+    fn iter(&self) -> Self::Iter {
+        todo!()
+    }
+}
+
+pub struct ImplsIn<'a> {
+    pub impls: Impls<'a>,
+    pub partition: Id,
+}
+
+pub struct TypesIn<'a> {
+    pub types: Types<'a>,
+    pub partition: Id,
+}
+
+impl<'a, 'd> DefItems<'a, (&'a str, &'a Type)> for ImplsIn<'d> {
+    type Item = &'d Implementation;
+    type Iter = ImplsIter;
+
+    fn contains<K>(&self, key: K) -> bool
+    where
+        K: AsKey<(&'a str, &'a Type)>,
+    {
+        let (k, t) = key.as_key();
+        self.impls.contains_(k, t, self.partition)
+    }
+
+    fn get<K>(&self, key: K) -> K::Output
+    where
+        K: PolyGet<Self::Item>,
+        K: AsKey<(&'a str, &'a Type)>,
+    {
+        let (key_, ty) = key.as_key();
+        self.impls
+            .get_(key_, ty, self.partition, key)
+    }
+
+    fn help<K>(&self, _key: K) -> K::Output
+    where
+        K: PolyGet<Error> + AsKey<(&'a str, &'a Type)>,
+    {
+        todo!()
+    }
+
+    fn iter(&self) -> Self::Iter {
+        todo!()
+    }
+}
+
+impl<'a, 'd> DefItems<'a, &'a str> for TypesIn<'d> {
+    type Item = &'d Type;
+    type Iter = TypesIter;
+
+    fn contains<K>(&self, key: K) -> bool
+    where
+        K: AsKey<&'a str>,
+    {
+        self.types.contains_(key.as_key(), self.partition)
+    }
+
+    fn get<K>(&self, key: K) -> K::Output
+    where
+        K: PolyGet<Self::Item>,
+        K: AsKey<&'a str>,
+    {
+        self.types
+            .get_(key.as_key(), self.partition, K::success, |f| key.fail(f))
+    }
+
+    fn help<K>(&self, _key: K) -> K::Output
+    where
+        K: PolyGet<Error> + AsKey<&'a str>,
     {
         todo!()
     }
@@ -339,98 +468,98 @@ impl Iterator for TypesIter {
     }
 }
 
-impl<T> PolyGet<T> for str {
-    type Output = Option<T>;
-    type Meta = ();
+macro_rules! key_impl {
+    ($($k:ty => $v:ident),*) => {
+        trait __GetTag {
+            fn __get_tag(&self) -> &Tag;
+        }
+        impl __GetTag for &Tag {
+            fn __get_tag(&self) -> &Tag { self }
+        }
+        impl<B> __GetTag for (&Tag, B) {
+            fn __get_tag(&self) -> &Tag { self.0 }
+        }
+        impl<B, C> __GetTag for (&Tag, B, C) {
+            fn __get_tag(&self) -> &Tag { self.0 }
+        }
 
-    fn key(&self) -> &str {
-        self
-    }
+        $(
+        key_impl!($v, $k, Id);
+        key_impl!($v, $k, BoundaryNode);
+        key_impl!($v, $k, TypeNode);
+        key_impl!($v, $k, ImplNode);
 
-    fn meta(&self) -> &Self::Meta {
-        &()
-    }
+        // polyget without id
+        key_impl!($v &$k);
+        key_impl!($v (&$k, &Type));
+        key_impl!(@askey 1, $k);
+        )*
+    };
+    ($v:ident, $k:ty, $id:ty) => {
+        // polyget with id
+        key_impl!($v (&$k, $id));
+        key_impl!($v (&$k, &Type, $id));
+        key_impl!(@askey 2, $k, $id);
+    };
+    (opt $t:ty) => {
+        impl<T> PolyGet<T> for $t {
+            type Output = Option<T>;
 
-    fn success(r: T) -> Self::Output {
-        Some(r)
-    }
+            fn success(r: T) -> Self::Output {
+                Some(r)
+            }
 
-    fn fail<E>(&self, _e: E) -> Self::Output
-    where
-        E: FnOnce(&Tag) -> Error,
-    {
-        None
-    }
+            fn fail<E>(&self, _e: E) -> Self::Output
+            where
+                E: FnOnce(&Tag) -> Error,
+            {
+                None
+            }
+        }
+    };
+    (res $t:ty) => {
+        impl<T> PolyGet<T> for $t {
+            type Output = Result<T>;
+
+            fn success(r: T) -> Self::Output {
+                Ok(r)
+            }
+
+            fn fail<E>(&self, e: E) -> Self::Output
+            where
+                E: FnOnce(&Tag) -> Error,
+            {
+                Err(e(__GetTag::__get_tag(self)))
+            }
+        }
+    };
+    (@askey 1, $k:ty) => {
+        impl<'a> AsKey<&'a str> for &'a $k {
+            fn as_key(&self) -> &'a str {
+                (*self).as_ref()
+            }
+        }
+        impl<'a, 'b> AsKey<(&'a str, &'b Type)> for (&'a $k, &'b Type) {
+            fn as_key(&self) -> (&'a str, &'b Type) {
+                let (a,b) = *self;
+                (a.as_ref(), b)
+            }
+        }
+    };
+    (@askey 2, $k:ty, $id:ty) => {
+        impl<'a> AsKey<(&'a str, Id)> for (&'a $k, $id) {
+            fn as_key(&self) -> (&'a str, Id) {
+                let (a,b) = *self;
+                (a.as_ref(), Id::from(b))
+            }
+        }
+        impl<'a, 'b> AsKey<(&'a str, &'b Type, Id)> for (&'a $k, &'b Type, $id) {
+            fn as_key(&self) -> (&'a str, &'b Type, Id) {
+                let (a,b,c) = *self;
+                (a.as_ref(), b, Id::from(c))
+            }
+        }
+    };
 }
 
-impl<T> PolyGet<T> for Tag {
-    type Output = Result<T>;
-    type Meta = ();
-
-    fn key(&self) -> &str {
-        self.str()
-    }
-
-    fn meta(&self) -> &Self::Meta {
-        &()
-    }
-
-    fn success(r: T) -> Self::Output {
-        Ok(r)
-    }
-
-    fn fail<E>(&self, e: E) -> Self::Output
-    where
-        E: FnOnce(&Tag) -> Error,
-    {
-        Err(e(self))
-    }
-}
-
-impl<T> PolyGet<T> for (&str, &Type) {
-    type Output = Option<T>;
-    type Meta = Type;
-
-    fn key(&self) -> &str {
-        self.0
-    }
-
-    fn meta(&self) -> &Self::Meta {
-        self.1
-    }
-
-    fn success(r: T) -> Self::Output {
-        Some(r)
-    }
-
-    fn fail<E>(&self, _e: E) -> Self::Output
-    where
-        E: FnOnce(&Tag) -> Error,
-    {
-        None
-    }
-}
-
-impl<T> PolyGet<T> for (&Tag, &Type) {
-    type Output = Result<T>;
-    type Meta = Type;
-
-    fn key(&self) -> &str {
-        self.0.str()
-    }
-
-    fn meta(&self) -> &Self::Meta {
-        self.1
-    }
-
-    fn success(r: T) -> Self::Output {
-        Ok(r)
-    }
-
-    fn fail<E>(&self, e: E) -> Self::Output
-    where
-        E: FnOnce(&Tag) -> Error,
-    {
-        Err(e(self.0))
-    }
-}
+key_impl!(str => opt, Tag => res);

--- a/ogma/src/lang/defs2/mod.rs
+++ b/ogma/src/lang/defs2/mod.rs
@@ -202,7 +202,7 @@ impl<'a> Impls<'a> {
 
     fn get_<K>(&self, key: &str, ty: &Type, within: Id, k_: K) -> K::Output
     where
-        K: PolyGet<&'a Implementation>
+        K: PolyGet<&'a Implementation>,
     {
         let (bnd, imports) = self.0.partitions.bnd_and_imports(within);
 
@@ -400,8 +400,7 @@ impl<'a, 'd> DefItems<'a, (&'a str, &'a Type)> for ImplsIn<'d> {
         K: AsKey<(&'a str, &'a Type)>,
     {
         let (key_, ty) = key.as_key();
-        self.impls
-            .get_(key_, ty, self.partition, key)
+        self.impls.get_(key_, ty, self.partition, key)
     }
 
     fn help<K>(&self, _key: K) -> K::Output

--- a/ogma/src/lang/defs2/tests.rs
+++ b/ogma/src/lang/defs2/tests.rs
@@ -55,9 +55,11 @@ fn api_smoke_test() {
 
     let k = String::from("foo");
 
-    let _: Option<_> = d.types().get(k.as_str(), ROOT);
+    let _: Option<_> = d.types().get((k.as_str(), ROOT));
+    let _: Option<_> = d.impls().get((k.as_str(), &Type::Nil, ROOT));
 
-    let _: Option<_> = d.impls().get(&(k.as_str(), &Type::Nil), ROOT);
+    let _: Option<_> = d.types().within(ROOT).get(k.as_str());
+    let _: Option<_> = d.impls().within(ROOT).get((k.as_str(), &Type::Nil));
 
     drop(k); // ensure d outlives k
 
@@ -68,9 +70,11 @@ fn api_smoke_test() {
         anchor: ast::Location::Shell,
     });
 
-    let _: Result<_> = d.types().get(&k, ROOT);
+    let _: Result<_> = d.types().get((&k, ROOT));
+    let _: Result<_> = d.impls().get((&k, &Type::Nil, ROOT));
 
-    let _: Result<_> = d.impls().get(&(&k, &Type::Nil), ROOT);
+    let _: Result<_> = d.types().within(ROOT).get(&k);
+    let _: Result<_> = d.impls().within(ROOT).get((&k, &Type::Nil));
 
     drop(k); // ensure d outlives k
 }


### PR DESCRIPTION
Extends the definitions API such that it can curry the partition `Id`.

This makes some funky use of the type system to achieve this.