### PR TITLE
Transition graphs

### DIFF
--- a/ogma/src/common/err.rs
+++ b/ogma/src/common/err.rs
@@ -224,29 +224,27 @@ impl Error {
     }
 
     pub(crate) fn op_not_found2(op: &Tag, recursion_detected: bool, impls: ImplsIn) -> Self {
-        todo!()
-        //         let hlp = if recursion_detected {
-        //             "recursion is not supported.
-        //           for alternatives, please see <https://daedalus.report/d/docs/ogma.book/11%20(no)%20recursion.md?pwd-raw=docs>".into()
-        //         } else if ty.is_empty() {
-        //             "view a list of definitions using `def --list`".into()
-        //         } else {
-        //             ty.into_iter().fold(
-        //                 format!("`{op}` is implemented for the following input types:"),
-        //                 |s, t| s + " " + &tystr(t.ty),
-        //             )
-        //         };
-        //
-        //         Error {
-        //             cat: Category::UnknownCommand,
-        //             desc: format!("operation `{op}` not defined"),
-        //             traces: trace(
-        //                 op,
-        //                 None,
-        //             ),
-        //             help_msg: Some(hlp),
-        //             hard: true,
-        //         }
+        let alts = impls.fuzzy_find(op.str()).collect::<Vec<_>>();
+
+        let hlp = if recursion_detected {
+            "recursion is not supported.
+          for alternatives, please see <https://daedalus.report/d/docs/ogma.book/11%20(no)%20recursion.md?pwd-raw=docs>".into()
+        } else if alts.is_empty() {
+            "view a list of definitions using `def --list`".into()
+        } else {
+            alts.into_iter().fold(
+                format!("`{op}` is implemented for the following input types:"),
+                |s, t| s + " " + t.name,
+            )
+        };
+
+        Error {
+            cat: Category::UnknownCommand,
+            desc: format!("operation `{op}` not defined"),
+            traces: trace(op, None),
+            help_msg: Some(hlp),
+            hard: true,
+        }
     }
 
     pub(crate) fn impl_not_found(op: &Tag, in_ty: &Type) -> Self {

--- a/ogma/src/common/err.rs
+++ b/ogma/src/common/err.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     lang::{
+        defs2::ImplsIn,
         help::*,
         syntax::ast::*,
         types::{Type, TypeDef},
@@ -139,6 +140,12 @@ pub fn help_as_error(msg: &HelpMessage, in_ty: Option<&Type>) -> Error {
     }
 }
 
+pub fn help_msg_ambiguous_import() -> Option<String> {
+    "check your imports for ambiguity\nconsider using fully qualified path syntax"
+        .to_string()
+        .into()
+}
+
 // ###### ERROR ################################################################
 /// Create a single trace item using the tag.
 pub fn trace<D: Into<Option<String>>>(tag: &Tag, desc: D) -> Vec<Trace> {
@@ -214,6 +221,32 @@ impl Error {
             help_msg: Some(hlp),
             hard: true,
         }
+    }
+
+    pub(crate) fn op_not_found2(op: &Tag, recursion_detected: bool, impls: ImplsIn) -> Self {
+        todo!()
+        //         let hlp = if recursion_detected {
+        //             "recursion is not supported.
+        //           for alternatives, please see <https://daedalus.report/d/docs/ogma.book/11%20(no)%20recursion.md?pwd-raw=docs>".into()
+        //         } else if ty.is_empty() {
+        //             "view a list of definitions using `def --list`".into()
+        //         } else {
+        //             ty.into_iter().fold(
+        //                 format!("`{op}` is implemented for the following input types:"),
+        //                 |s, t| s + " " + &tystr(t.ty),
+        //             )
+        //         };
+        //
+        //         Error {
+        //             cat: Category::UnknownCommand,
+        //             desc: format!("operation `{op}` not defined"),
+        //             traces: trace(
+        //                 op,
+        //                 None,
+        //             ),
+        //             help_msg: Some(hlp),
+        //             hard: true,
+        //         }
     }
 
     pub(crate) fn impl_not_found(op: &Tag, in_ty: &Type) -> Self {

--- a/ogma/src/eng/annotate.rs
+++ b/ogma/src/eng/annotate.rs
@@ -54,7 +54,7 @@ fn fmt(s: &mut String, blk: &Block, node: petgraph::prelude::NodeIndex, v: bool)
             write!(s, " }}").unwrap();
             fmt_ty(s, out_ty)
         }
-        Op { op: _, blk: _ } => fmt_op(s, blk, OpNode(node), v),
+        Op { op: _, blk: _, within: _ } => fmt_op(s, blk, OpNode(node), v),
         Def { .. } | Intrinsic { .. } | Flag { .. } => unreachable!(),
     }
 }

--- a/ogma/src/eng/annotate.rs
+++ b/ogma/src/eng/annotate.rs
@@ -54,7 +54,11 @@ fn fmt(s: &mut String, blk: &Block, node: petgraph::prelude::NodeIndex, v: bool)
             write!(s, " }}").unwrap();
             fmt_ty(s, out_ty)
         }
-        Op { op: _, blk: _, within: _ } => fmt_op(s, blk, OpNode(node), v),
+        Op {
+            op: _,
+            blk: _,
+            within: _,
+        } => fmt_op(s, blk, OpNode(node), v),
         Def { .. } | Intrinsic { .. } | Flag { .. } => unreachable!(),
     }
 }

--- a/ogma/src/eng/arg.rs
+++ b/ogma/src/eng/arg.rs
@@ -215,7 +215,11 @@ impl<'a> ArgBuilder<'a> {
         } = compiler;
 
         match &ag[node.idx()] {
-            Op { op: _, blk: _, within: _ } => unreachable!("an argument cannot be an Op variant"),
+            Op {
+                op: _,
+                blk: _,
+                within: _,
+            } => unreachable!("an argument cannot be an Op variant"),
             Flag(_) => unreachable!("an argument cannot be a Flag variant"),
             Intrinsic { .. } => unreachable!("an argument cannot be a Intrinsic variant"),
             Def { .. } => unreachable!("an argument cannot be a Def variant"),

--- a/ogma/src/eng/arg.rs
+++ b/ogma/src/eng/arg.rs
@@ -215,7 +215,7 @@ impl<'a> ArgBuilder<'a> {
         } = compiler;
 
         match &ag[node.idx()] {
-            Op { op: _, blk: _ } => unreachable!("an argument cannot be an Op variant"),
+            Op { op: _, blk: _, within: _ } => unreachable!("an argument cannot be an Op variant"),
             Flag(_) => unreachable!("an argument cannot be a Flag variant"),
             Intrinsic { .. } => unreachable!("an argument cannot be a Intrinsic variant"),
             Def { .. } => unreachable!("an argument cannot be a Def variant"),

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -36,7 +36,8 @@ pub fn compile_with_seed_vars(
     anon_tys: &AnonTypes,
     seed_vars: var::SeedVars,
 ) -> Result<FullCompilation> {
-    let (ag, chgs) = astgraph::init(expr, defs)?; // flatten and expand expr/defs
+    let defs2 = defs2::Definitions::new();
+    let (ag, chgs) = astgraph::init(expr, &defs2)?; // flatten and expand expr/defs
     let tg = TypeGraph::build(&ag, defs.types());
     let lg = LocalsGraph::build(&ag);
 

--- a/ogma/src/eng/comp/mod.rs
+++ b/ogma/src/eng/comp/mod.rs
@@ -38,7 +38,7 @@ pub fn compile_with_seed_vars(
 ) -> Result<FullCompilation> {
     let defs2 = defs2::Definitions::new();
     let (ag, chgs) = astgraph::init(expr, &defs2)?; // flatten and expand expr/defs
-    let tg = TypeGraph::build(&ag, defs.types());
+    let tg = TypeGraph::build(&ag, defs2.types());
     let lg = LocalsGraph::build(&ag);
 
     let mut compiler = Box::new(Compiler {

--- a/ogma/src/eng/graphs/astgraph.rs
+++ b/ogma/src/eng/graphs/astgraph.rs
@@ -193,7 +193,11 @@ impl AstGraph {
                     }
                 };
 
-                let op = g.add_node(AstNode::Op { op, blk: blk_tag, within });
+                let op = g.add_node(AstNode::Op {
+                    op,
+                    blk: blk_tag,
+                    within,
+                });
                 g.add_edge(root, op, Relation::Normal); // edge from the expression root to the op
 
                 if let Some(t) = map_ty_tag(in_ty, tys)? {
@@ -759,7 +763,11 @@ impl AstNode {
         use AstNode::*;
 
         match self {
-            Op { op, blk: _, within: _ } => op,
+            Op {
+                op,
+                blk: _,
+                within: _,
+            } => op,
             Intrinsic { op, intrinsic: _ } => op,
             Def { expr, params: _ } => expr,
             Flag(f) => f,

--- a/ogma/src/eng/graphs/mod.rs
+++ b/ogma/src/eng/graphs/mod.rs
@@ -123,13 +123,13 @@ mod tests {
     use tygraph::*;
 
     fn init_graphs(expr: &str) -> (AstGraph, TypeGraph) {
-        init_graphs_w_defs(expr, &Definitions::default())
+        init_graphs_w_defs(expr, &Definitions::default(), &defs2::Definitions::new())
     }
 
-    fn init_graphs_w_defs(expr: &str, defs: &Definitions) -> (AstGraph, TypeGraph) {
+    fn init_graphs_w_defs(expr: &str, defs: &Definitions, defs2: &defs2::Definitions) -> (AstGraph, TypeGraph) {
         let expr = lang::parse::expression(expr, Default::default(), defs).unwrap();
 
-        let (ag, _) = astgraph::init(expr, defs).unwrap();
+        let (ag, _) = astgraph::init(expr, defs2).unwrap();
         let tg = TypeGraph::build(&ag, defs.types());
         (ag, tg)
     }
@@ -521,6 +521,8 @@ mod tests {
     #[test]
     fn def_tg_linking_def_and_intrinsic() {
         let defs = &mut Definitions::default();
+        let defs2 = &mut defs2::Definitions::new();
+
         lang::process_definition(
             "def cmp Table (a b) { \\ #t }",
             Default::default(),
@@ -529,7 +531,7 @@ mod tests {
         )
         .unwrap();
 
-        let (ag, mut tg) = init_graphs_w_defs("cmp 'one' 'two'", defs);
+        let (ag, mut tg) = init_graphs_w_defs("cmp 'one' 'two'", defs, defs2);
 
         tg.apply_ast_types(&ag);
         tg.apply_ast_edges(&ag);
@@ -566,6 +568,8 @@ mod tests {
     #[test]
     fn def_tg_linking_multiple_defs_params() {
         let defs = &mut Definitions::default();
+        let defs2 = &mut defs2::Definitions::new();
+
         lang::process_definition(
             "def foo Nil (a b c) { \\ #t }",
             Default::default(),
@@ -588,7 +592,7 @@ mod tests {
         )
         .unwrap();
 
-        let (ag, mut tg) = init_graphs_w_defs("foo 1 2 3", defs);
+        let (ag, mut tg) = init_graphs_w_defs("foo 1 2 3", defs, defs2);
 
         tg.apply_ast_types(&ag);
         tg.apply_ast_edges(&ag);
@@ -650,6 +654,8 @@ mod tests {
     #[test]
     fn tg_types_with_keyed_some() {
         let defs = &mut Definitions::default();
+        let defs2 = &mut defs2::Definitions::new();
+
         lang::process_definition(
             "def foo Nil (a b) { \\ #t }",
             Default::default(),
@@ -658,7 +664,7 @@ mod tests {
         )
         .unwrap();
 
-        let (ag, mut tg) = init_graphs_w_defs("foo 2", defs);
+        let (ag, mut tg) = init_graphs_w_defs("foo 2", defs, defs2);
 
         tg.apply_ast_types(&ag);
         tg.apply_ast_edges(&ag);
@@ -678,6 +684,8 @@ mod tests {
     #[test]
     fn ag_init_endless_loop() {
         let defs = &mut Definitions::default();
+        let defs2 = &mut defs2::Definitions::new();
+
         // point def
         lang::process_definition(
             "def-ty Point { x:Num y:Num }",
@@ -688,13 +696,14 @@ mod tests {
         .unwrap();
         lang::process_definition("def + Point (rhs) { Point { get x | + { \\ $rhs | get x } } { get y | + { \\ $rhs | get y } } }", Default::default(), None, defs).unwrap();
 
-        let _ = init_graphs_w_defs("Point 1 3", defs);
-        let _ = init_graphs_w_defs("Point 1 3 | + Point -2 2", defs);
+        let _ = init_graphs_w_defs("Point 1 3", defs, defs2);
+        let _ = init_graphs_w_defs("Point 1 3 | + Point -2 2", defs, defs2);
     }
 
     #[test]
     fn ag_recursion_testing() {
         let defs = &mut Definitions::default();
+        let defs2 = &mut defs2::Definitions::new();
 
         lang::process_definition("def-ty Foo :: Bar", Default::default(), None, defs).unwrap();
         lang::process_definition(
@@ -705,7 +714,7 @@ mod tests {
         )
         .unwrap();
 
-        init_graphs_w_defs("Foo::Bar | + Foo::Bar", defs);
+        init_graphs_w_defs("Foo::Bar | + Foo::Bar", defs, defs2);
     }
 
     #[test]

--- a/ogma/src/eng/graphs/mod.rs
+++ b/ogma/src/eng/graphs/mod.rs
@@ -126,7 +126,11 @@ mod tests {
         init_graphs_w_defs(expr, &Definitions::default(), &defs2::Definitions::new())
     }
 
-    fn init_graphs_w_defs(expr: &str, defs: &Definitions, defs2: &defs2::Definitions) -> (AstGraph, TypeGraph) {
+    fn init_graphs_w_defs(
+        expr: &str,
+        defs: &Definitions,
+        defs2: &defs2::Definitions,
+    ) -> (AstGraph, TypeGraph) {
         let expr = lang::parse::expression(expr, Default::default(), defs).unwrap();
 
         let (ag, _) = astgraph::init(expr, defs2).unwrap();

--- a/ogma/src/eng/graphs/mod.rs
+++ b/ogma/src/eng/graphs/mod.rs
@@ -134,7 +134,7 @@ mod tests {
         let expr = lang::parse::expression(expr, Default::default(), defs).unwrap();
 
         let (ag, _) = astgraph::init(expr, defs2).unwrap();
-        let tg = TypeGraph::build(&ag, defs.types());
+        let tg = TypeGraph::build(&ag, defs2.types());
         (ag, tg)
     }
 
@@ -203,8 +203,8 @@ mod tests {
 
         use tygraph::{Knowledge, Node};
         let def = || Node {
-            input: TypesSet::full(Definitions::new().types()).into(),
-            output: TypesSet::full(Definitions::new().types()).into(),
+            input: TypesSet::full(defs2::Definitions::new().types()).into(),
+            output: TypesSet::full(defs2::Definitions::new().types()).into(),
         };
 
         assert_eq!(tg.node_weight(0.into()), Some(&def())); // root
@@ -302,8 +302,8 @@ mod tests {
         // Type graph nodes
         use tygraph::{Flow, Knowledge, Node};
         let def = || Node {
-            input: TypesSet::full(Definitions::new().types()).into(),
-            output: TypesSet::full(Definitions::new().types()).into(),
+            input: TypesSet::full(defs2::Definitions::new().types()).into(),
+            output: TypesSet::full(defs2::Definitions::new().types()).into(),
         };
 
         assert_eq!(tg.node_weight(0.into()), Some(&def())); // root
@@ -450,8 +450,8 @@ mod tests {
         // Type graph nodes
         use tygraph::{Flow, Knowledge, Node};
         let def = || Node {
-            input: TypesSet::full(&Definitions::new().types()).into(),
-            output: TypesSet::full(&Definitions::new().types()).into(),
+            input: TypesSet::full(defs2::Definitions::new().types()).into(),
+            output: TypesSet::full(defs2::Definitions::new().types()).into(),
         };
 
         assert_eq!(tg.edge_count(), 9);
@@ -657,7 +657,7 @@ mod tests {
 
     #[test]
     fn tg_types_with_keyed_some() {
-        let defs = &mut Definitions::default();
+        let defs = &mut Definitions::new();
         let defs2 = &mut defs2::Definitions::new();
 
         lang::process_definition(
@@ -680,7 +680,7 @@ mod tests {
             tg.node_weight(idx),
             Some(&Node {
                 input: Knowledge::Known(Type::Nil),
-                output: TypesSet::full(defs.types()).into(),
+                output: TypesSet::full(defs2.types()).into(),
             })
         ); // 3
     }

--- a/ogma/src/eng/graphs/tygraph.rs
+++ b/ogma/src/eng/graphs/tygraph.rs
@@ -1,8 +1,8 @@
 use super::*;
-use crate::lang::types::Types;
 use astgraph::*;
 use petgraph::prelude::*;
 use std::{iter, ops::Deref, rc::Rc};
+use defs2::Types;
 
 type TypeGraphInner = petgraph::stable_graph::StableGraph<Node, Flow, petgraph::Directed, u32>;
 
@@ -130,7 +130,7 @@ impl TypeGraph {
     }
 
     /// Builds a type graph based off the ast graph.
-    pub fn build(ast_graph: &AstGraph, tys: &Types) -> Self {
+    pub fn build(ast_graph: &AstGraph, tys: Types) -> Self {
         let full = TypesSet::full(tys);
 
         let mut g = ast_graph.map(
@@ -831,9 +831,9 @@ impl TypesSet {
     }
 
     /// Return a full set of types.
-    pub fn full(tys: &Types) -> Self {
+    pub fn full(tys: Types) -> Self {
         let mut s = Self::empty();
-        for t in tys.iter().map(|(_, x)| x.clone()) {
+        for t in tys.iter().cloned() {
             s.insert(t);
         }
         s

--- a/ogma/src/lang/defs2/mod.rs
+++ b/ogma/src/lang/defs2/mod.rs
@@ -607,7 +607,7 @@ impl<'a, 'd> DefItems<'a, (&'a str, &'a Type, Id)> for Impls<'d> {
 
 impl<'a, 'd> DefItems<'a, (&'a str, Id)> for Types<'d> {
     type Item = &'d Type;
-    type Iter = TypesIter;
+    type Iter = TypesIter<'a>;
 
     fn contains<K>(&self, key: K) -> bool
     where
@@ -706,7 +706,7 @@ impl<'a, 'd> DefItems<'a, (&'a str, &'a Type)> for ImplsIn<'d> {
 
 impl<'a, 'd> DefItems<'a, &'a str> for TypesIn<'d> {
     type Item = &'d Type;
-    type Iter = TypesIter;
+    type Iter = TypesIter<'a>;
 
     fn contains<K>(&self, key: K) -> bool
     where
@@ -765,15 +765,7 @@ impl Iterator for ImplsIter {
     }
 }
 
-pub struct TypesIter {}
-
-impl Iterator for TypesIter {
-    type Item = ();
-
-    fn next(&mut self) -> Option<Self::Item> {
-        todo!()
-    }
-}
+type TypesIter<'a> = std::collections::hash_map::Values<'a, TypeNode, Type>;
 
 macro_rules! key_impl {
     ($($k:ty => $v:ident),*) => {

--- a/ogma/src/lang/defs2/partitions/mod.rs
+++ b/ogma/src/lang/defs2/partitions/mod.rs
@@ -484,7 +484,7 @@ impl Partitions {
         Ok(a)
     }
 
-    fn fuzzy_find<P: AsRef<str>>(
+    pub fn fuzzy_find<P: AsRef<str>>(
         &self,
         parent: BoundaryNode,
         n: P,
@@ -548,6 +548,20 @@ impl Partitions {
         self.find(within, imports, path)
             .into_iter()
             .filter_map(|n| self[n].is_impl().then_some(ImplNode(n)))
+    }
+
+    /// Finds the boundary nodes which match `path` from the given `within` partition.
+    ///
+    /// Looks within the `imports`, use [`PartSet::empty`] if no imports.
+    pub fn find_boundaries(
+        &self,
+        within: BoundaryNode,
+        imports: &PartSet,
+        path: &str,
+    ) -> impl Iterator<Item = BoundaryNode> + '_ {
+        self.find(within, imports, path)
+            .into_iter()
+            .filter_map(|n| self[n].is_boundary().then_some(BoundaryNode(n)))
     }
 
     /// Find all [`Id]s that match `path`, from `within` the partition and `imports`.

--- a/ogma/src/lang/defs2/partitions/partset.rs
+++ b/ogma/src/lang/defs2/partitions/partset.rs
@@ -55,6 +55,10 @@ impl PartSet {
         self.0[lwr..upr].iter().copied()
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = Id> + '_ {
+        self.0.iter().copied()
+    }
+
     #[cfg(test)]
     pub fn eq_names(&self, parts: &Partitions, names: &[&str]) -> bool {
         let names_ = self

--- a/ogma/src/lang/types/tests.rs
+++ b/ogma/src/lang/types/tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use quickcheck::{Arbitrary, Gen};
 use Type::*;

--- a/ogma/src/lang/types/tests.rs
+++ b/ogma/src/lang/types/tests.rs
@@ -1,0 +1,208 @@
+
+use super::*;
+use quickcheck::{Arbitrary, Gen};
+use Type::*;
+
+impl Arbitrary for Type {
+    fn arbitrary(g: &mut Gen) -> Self {
+        match u8::arbitrary(g) % 6 {
+            0 => Nil,
+            1 => Bool,
+            2 => Num,
+            3 => Str,
+            4 => Tab,
+            5 => TabRow,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[test]
+fn display_impl() {
+    let ty = vec![Nil, Bool, Num, Str, Tab, TabRow, Def(ORD.get())]
+        .iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    assert_eq!(&ty, "Nil, Bool, Number, String, Table, TableRow, Ord");
+}
+
+fn x(t: Type) -> String {
+    crate::common::err::help_as_error(&t.help(), None).to_string()
+}
+
+#[test]
+fn prim_type_help_messages() {
+    assert_eq!(
+        &x(Nil),
+        "Help: `Nil`
+--> shell:0
+ | ---- Input Type: <any> ----
+ | nothing value
+ | 
+ | Usage:
+ |  => Nil
+"
+    );
+    assert_eq!(
+        &x(Bool),
+        "Help: `Bool`
+--> shell:0
+ | ---- Input Type: <any> ----
+ | boolean value
+ | true | false
+ | 
+ | Usage:
+ |  => Bool
+"
+    );
+    assert_eq!(
+        &x(Num),
+        "Help: `Number`
+--> shell:0
+ | ---- Input Type: <any> ----
+ | number value
+ | 100 | -1 | 3.14 | -1.23e-5
+ | 
+ | Usage:
+ |  => Number
+"
+    );
+    assert_eq!(
+        &x(Str),
+        "Help: `String`
+--> shell:0
+ | ---- Input Type: <any> ----
+ | string value
+ | 
+ | Usage:
+ |  => String
+"
+    );
+    assert_eq!(
+        &x(Tab),
+        "Help: `Table`
+--> shell:0
+ | ---- Input Type: <any> ----
+ | table value
+ | 
+ | Usage:
+ |  => Table
+"
+    );
+    assert_eq!(
+        &x(TabRow),
+        "Help: `TableRow`
+--> shell:0
+ | ---- Input Type: <any> ----
+ | table row
+ | 
+ | Usage:
+ |  => TableRow
+"
+    );
+}
+
+#[test]
+fn ord_ty_help_msg() {
+    assert_eq!(
+        &x(Def(ORD.get())),
+        "Help: `Ord`
+--> shell:0
+ | ---- Input Type: <any> ----
+ | <ogma>
+ | `def-ty Ord :: Lt | Eq | Gt`
+ | 
+ | Usage:
+ |  => Ord
+"
+    );
+}
+
+#[test]
+fn tuple_type_testing() {
+    let args = [Type::Nil, Type::Num, Type::Str];
+
+    let ty = Tuple::ty(args[..2].to_vec());
+    assert_eq!(ty.name().str(), "U_Nil-Num_");
+    match ty.structure() {
+        TypeVariant::Product(x) => {
+            assert_eq!(x[0].name().str(), "t0");
+            assert_eq!(x[0].ty(), &Type::Nil);
+            assert_eq!(x[1].name().str(), "t1");
+            assert_eq!(x[1].ty(), &Type::Num);
+        }
+        _ => panic!(),
+    }
+
+    let ty = Tuple::ty(args[1..].to_vec());
+    assert_eq!(ty.name().str(), "U_Num-Str_");
+    match ty.structure() {
+        TypeVariant::Product(x) => {
+            assert_eq!(x[0].name().str(), "t0");
+            assert_eq!(x[0].ty(), &Type::Num);
+            assert_eq!(x[1].name().str(), "t1");
+            assert_eq!(x[1].ty(), &Type::Str);
+        }
+        _ => panic!(),
+    }
+
+    let ty = Tuple::ty(args[..].to_vec());
+    assert_eq!(ty.name().str(), "U_Nil-Num-Str_");
+    match ty.structure() {
+        TypeVariant::Product(x) => {
+            assert_eq!(x[0].name().str(), "t0");
+            assert_eq!(x[0].ty(), &Type::Nil);
+            assert_eq!(x[1].name().str(), "t1");
+            assert_eq!(x[1].ty(), &Type::Num);
+            assert_eq!(x[2].name().str(), "t2");
+            assert_eq!(x[2].ty(), &Type::Str);
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn tuple_parse_name_testing() {
+    let tys = crate::prelude::Definitions::new();
+    assert_eq!(
+        Some(Type::Def(Arc::new(Tuple::ty(vec![
+            Type::Nil,
+            Type::Num,
+            Type::Str
+        ])))),
+        Tuple::parse_name("U_Nil-Num-Str_", tys.types())
+    )
+}
+
+#[test]
+fn split_parse_testing() {
+    use Split::*;
+    let f = Split::parse;
+
+    assert_eq!(f(""), None);
+    assert_eq!(f("fdsaff sfdsa"), None);
+    assert_eq!(f("   "), None);
+    assert_eq!(f("U__"), None);
+    assert_eq!(f("U_    _"), Some(Tuple(vec![Ty("    ")])));
+    assert_eq!(f("U_Nil_"), Some(Tuple(vec![Ty("Nil")])));
+    assert_eq!(
+        f("U_Nil-Num-Str_"),
+        Some(Tuple(vec![Ty("Nil"), Ty("Num"), Ty("Str")]))
+    );
+    assert_eq!(f("U_Nil-Num-Str-_"), None);
+    assert_eq!(f("U_Nil-Num-Str"), None);
+    assert_eq!(
+        f("U_Nil-U_Num-Str_-Str_"),
+        Some(Tuple(vec![
+            Ty("Nil"),
+            Tuple(vec![Ty("Num"), Ty("Str")]),
+            Ty("Str")
+        ]))
+    );
+}
+
+#[quickcheck]
+fn type_cmp(a: Type, b: Type) -> bool {
+    a.cmp(&b) == b.cmp(&a).reverse()
+}


### PR DESCRIPTION
Move the building of the AST and type graph to use `defs2::Definitions`.